### PR TITLE
Set up CalibrateMe project: complete codebase from starter docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+coverage/
+.vite/
+*.log

--- a/index.html
+++ b/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>CalibrateMe</title>
+    <style>
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      body {
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
+        background-color: #f5f5f5;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,0 +1,17 @@
+/** @type {import('jest').Config} */
+const config = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/src', '<rootDir>/tests'],
+  testMatch: ['**/*.test.ts'],
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+  },
+  collectCoverageFrom: [
+    'src/**/*.ts',
+    '!src/**/*.d.ts',
+    '!src/main.tsx',
+  ],
+};
+
+module.exports = config;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,5352 @@
+{
+  "name": "calibrateme",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "calibrateme",
+      "version": "1.0.0",
+      "dependencies": {
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
+        "recharts": "^2.10.0",
+        "zustand": "^4.4.0"
+      },
+      "devDependencies": {
+        "@types/jest": "^29.5.0",
+        "@types/react": "^18.2.0",
+        "@types/react-dom": "^18.2.0",
+        "@vitejs/plugin-react": "^4.2.0",
+        "jest": "^29.7.0",
+        "ts-jest": "^29.1.0",
+        "typescript": "^5.3.0",
+        "vite": "^5.0.0"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
+      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
+      "integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
+      "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-async-generators": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
+      "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-bigint": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
+      "integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-class-properties": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
+      "integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-class-static-block": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz",
+      "integrity": "sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-import-attributes": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.28.6.tgz",
+      "integrity": "sha512-jiLC0ma9XkQT3TKJ9uYvlakm66Pamywo+qwL+oL8HJOvc6TWdZXVfhqJr8CCzbSGUAbDOzlGHJC1U+vRfLQDvw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-import-meta": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
+      "integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-json-strings": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
+      "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-jsx": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.28.6.tgz",
+      "integrity": "sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-logical-assignment-operators": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
+      "integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-nullish-coalescing-operator": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
+      "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-numeric-separator": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
+      "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-object-rest-spread": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
+      "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-optional-catch-binding": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
+      "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-optional-chaining": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
+      "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-private-property-in-object": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
+      "integrity": "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-top-level-await": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
+      "integrity": "sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-typescript": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.28.6.tgz",
+      "integrity": "sha512-+nDNmQye7nlnuuHDboPbGm00Vqg3oO8niRRL27/4LYHUsHYh0zJ1xWOz0uRwNFmM1Avzk8wZbc6rdiYhomzv/A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
+      "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
+      "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
+      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
+      "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.3.1",
+        "find-up": "^4.1.0",
+        "get-package-type": "^0.1.0",
+        "js-yaml": "^3.13.1",
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/console": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.7.0.tgz",
+      "integrity": "sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/core": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-29.7.0.tgz",
+      "integrity": "sha512-n7aeXWKMnGtDA48y8TLWJPJmLmmZ642Ceo78cYWEpiD7FzDgmNDV/GCVRorPABdXLJZ/9wzzgZAlHjXjxDHGsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/reporters": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.9",
+        "jest-changed-files": "^29.7.0",
+        "jest-config": "^29.7.0",
+        "jest-haste-map": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-resolve-dependencies": "^29.7.0",
+        "jest-runner": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "jest-watcher": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/environment": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
+      "integrity": "sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "jest-mock": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/expect": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha512-8uMeAMycttpva3P1lBHB8VciS9V0XAr3GymPpipdyQXbBcuhkLQOSe8E/p92RyAdToS6ZD1tFkX+CkhoECE0dQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "^29.7.0",
+        "jest-snapshot": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/expect-utils": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.7.0.tgz",
+      "integrity": "sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-get-type": "^29.6.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/fake-timers": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.7.0.tgz",
+      "integrity": "sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@sinonjs/fake-timers": "^10.0.2",
+        "@types/node": "*",
+        "jest-message-util": "^29.7.0",
+        "jest-mock": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/globals": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
+      "integrity": "sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/expect": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "jest-mock": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/reporters": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.7.0.tgz",
+      "integrity": "sha512-DApq0KJbJOEzAFYjHADNNxAE3KbhxQB1y5Kplb5Waqw6zVbuWatSnMjE5gs8FUgEPmNsnZA3NCWl9NG0ia04Pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^0.2.3",
+        "@jest/console": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "collect-v8-coverage": "^1.0.0",
+        "exit": "^0.1.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "istanbul-lib-coverage": "^3.0.0",
+        "istanbul-lib-instrument": "^6.0.0",
+        "istanbul-lib-report": "^3.0.0",
+        "istanbul-lib-source-maps": "^4.0.0",
+        "istanbul-reports": "^3.1.3",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "slash": "^3.0.0",
+        "string-length": "^4.0.1",
+        "strip-ansi": "^6.0.0",
+        "v8-to-istanbul": "^9.0.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/source-map": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.6.3.tgz",
+      "integrity": "sha512-MHjT95QuipcPrpLM+8JMSzFx6eHp5Bm+4XeFDJlwsvVBjmKNiIAvasGK2fxz2WbGRlnvqehFbh07MMa7n3YJnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "callsites": "^3.0.0",
+        "graceful-fs": "^4.2.9"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/test-result": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.7.0.tgz",
+      "integrity": "sha512-Fdx+tv6x1zlkJPcWXmMDAG2HBnaR9XPSd5aDWQVsfrZmLVT3lU1cwyxLgRmXR9yrq4NBoEm9BMsfgFzTQAbJYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "collect-v8-coverage": "^1.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/test-sequencer": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.7.0.tgz",
+      "integrity": "sha512-GQwJ5WZVrKnOJuiYiAF52UNUJXgTZx1NHjFSEB0qEMmSZKAkdMoIzw/Cj6x6NF4AvV23AUqDpFzQkN/eYCYTxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/test-result": "^29.7.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/transform": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
+      "integrity": "sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@jest/types": "^29.6.3",
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "babel-plugin-istanbul": "^6.1.1",
+        "chalk": "^4.0.0",
+        "convert-source-map": "^2.0.0",
+        "fast-json-stable-stringify": "^2.1.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "pirates": "^4.0.4",
+        "slash": "^3.0.0",
+        "write-file-atomic": "^4.0.2"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/types": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
+      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.8",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.27",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.57.1.tgz",
+      "integrity": "sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.57.1.tgz",
+      "integrity": "sha512-dQaAddCY9YgkFHZcFNS/606Exo8vcLHwArFZ7vxXq4rigo2bb494/xKMMwRRQW6ug7Js6yXmBZhSBRuBvCCQ3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.57.1.tgz",
+      "integrity": "sha512-crNPrwJOrRxagUYeMn/DZwqN88SDmwaJ8Cvi/TN1HnWBU7GwknckyosC2gd0IqYRsHDEnXf328o9/HC6OkPgOg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.57.1.tgz",
+      "integrity": "sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.57.1.tgz",
+      "integrity": "sha512-R+/WwhsjmwodAcz65guCGFRkMb4gKWTcIeLy60JJQbXrJ97BOXHxnkPFrP+YwFlaS0m+uWJTstrUA9o+UchFug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.57.1.tgz",
+      "integrity": "sha512-IEQTCHeiTOnAUC3IDQdzRAGj3jOAYNr9kBguI7MQAAZK3caezRrg0GxAb6Hchg4lxdZEI5Oq3iov/w/hnFWY9Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.57.1.tgz",
+      "integrity": "sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.57.1.tgz",
+      "integrity": "sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.57.1.tgz",
+      "integrity": "sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.57.1.tgz",
+      "integrity": "sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.57.1.tgz",
+      "integrity": "sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.57.1.tgz",
+      "integrity": "sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.57.1.tgz",
+      "integrity": "sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.57.1.tgz",
+      "integrity": "sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.57.1.tgz",
+      "integrity": "sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.57.1.tgz",
+      "integrity": "sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.57.1.tgz",
+      "integrity": "sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.57.1.tgz",
+      "integrity": "sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.57.1.tgz",
+      "integrity": "sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.57.1.tgz",
+      "integrity": "sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.57.1.tgz",
+      "integrity": "sha512-4wYoDpNg6o/oPximyc/NG+mYUejZrCU2q+2w6YZqrAs2UcNUChIZXjtafAiiZSUc7On8v5NyNj34Kzj/Ltk6dQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.57.1.tgz",
+      "integrity": "sha512-O54mtsV/6LW3P8qdTcamQmuC990HDfR71lo44oZMZlXU4tzLrbvTii87Ni9opq60ds0YzuAlEr/GNwuNluZyMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.57.1.tgz",
+      "integrity": "sha512-P3dLS+IerxCT/7D2q2FYcRdWRl22dNbrbBEtxdWhXrfIMPP9lQhb5h4Du04mdl5Woq05jVCDPCMF7Ub0NAjIew==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.57.1.tgz",
+      "integrity": "sha512-VMBH2eOOaKGtIJYleXsi2B8CPVADrh+TyNxJ4mWPnKfLB/DBUmzW+5m1xUrcwWoMfSLagIRpjUFeW5CO5hyciQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.57.1.tgz",
+      "integrity": "sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.27.10",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
+      "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sinonjs/commons": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+      "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/fake-timers": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
+      "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.0"
+      }
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/graceful-fs": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
+      "integrity": "sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/istanbul-lib-coverage": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+      "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/istanbul-lib-report": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
+      "integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "*"
+      }
+    },
+    "node_modules/@types/istanbul-reports": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
+      "integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/istanbul-lib-report": "*"
+      }
+    },
+    "node_modules/@types/jest": {
+      "version": "29.5.14",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.14.tgz",
+      "integrity": "sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "^29.0.0",
+        "pretty-format": "^29.0.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.2.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.2.3.tgz",
+      "integrity": "sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@types/stack-utils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
+      "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/yargs": {
+      "version": "17.0.35",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
+      "integrity": "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/@types/yargs-parser": {
+      "version": "21.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
+      "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.27",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.17.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.21.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/babel-jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
+      "integrity": "sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/transform": "^29.7.0",
+        "@types/babel__core": "^7.1.14",
+        "babel-plugin-istanbul": "^6.1.1",
+        "babel-preset-jest": "^29.6.3",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.8.0"
+      }
+    },
+    "node_modules/babel-plugin-istanbul": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
+      "integrity": "sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@istanbuljs/load-nyc-config": "^1.0.0",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-instrument": "^5.0.4",
+        "test-exclude": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/babel-plugin-istanbul/node_modules/istanbul-lib-instrument": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
+      "integrity": "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/core": "^7.12.3",
+        "@babel/parser": "^7.14.7",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-coverage": "^3.2.0",
+        "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/babel-plugin-jest-hoist": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.6.3.tgz",
+      "integrity": "sha512-ESAc/RJvGTFEzRwOTT4+lNDk/GNHMkKbNzsvT0qKRfDyyYTskxB5rnU2njIDYVxXCBHHEI1c0YwHob3WaYujOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.3.3",
+        "@babel/types": "^7.3.3",
+        "@types/babel__core": "^7.1.14",
+        "@types/babel__traverse": "^7.0.6"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/babel-preset-current-node-syntax": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.2.0.tgz",
+      "integrity": "sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/plugin-syntax-async-generators": "^7.8.4",
+        "@babel/plugin-syntax-bigint": "^7.8.3",
+        "@babel/plugin-syntax-class-properties": "^7.12.13",
+        "@babel/plugin-syntax-class-static-block": "^7.14.5",
+        "@babel/plugin-syntax-import-attributes": "^7.24.7",
+        "@babel/plugin-syntax-import-meta": "^7.10.4",
+        "@babel/plugin-syntax-json-strings": "^7.8.3",
+        "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+        "@babel/plugin-syntax-numeric-separator": "^7.10.4",
+        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+        "@babel/plugin-syntax-optional-chaining": "^7.8.3",
+        "@babel/plugin-syntax-private-property-in-object": "^7.14.5",
+        "@babel/plugin-syntax-top-level-await": "^7.14.5"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0 || ^8.0.0-0"
+      }
+    },
+    "node_modules/babel-preset-jest": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.6.3.tgz",
+      "integrity": "sha512-0B3bhxR6snWXJZtR/RliHTDPRgn1sNHOR0yVtq/IiQFyuOVjFS+wuio/R4gSNkyYmKmJB4wGZv2NZanmKmTnNA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "babel-plugin-jest-hoist": "^29.6.3",
+        "babel-preset-current-node-syntax": "^1.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.9.19",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.19.tgz",
+      "integrity": "sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
+      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.9.0",
+        "caniuse-lite": "^1.0.30001759",
+        "electron-to-chromium": "^1.5.263",
+        "node-releases": "^2.0.27",
+        "update-browserslist-db": "^1.2.0"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/bs-logger": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
+      "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-json-stable-stringify": "2.x"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/bser": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
+      "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "node-int64": "^0.4.0"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001770",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001770.tgz",
+      "integrity": "sha512-x/2CLQ1jHENRbHg5PSId2sXq1CIO1CISvwWAj027ltMVG2UNgW+w9oH2+HzgEIRFembL8bUlXtfbBHR1fCg2xw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/char-regex": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
+      "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ci-info": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
+      "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">= 1.0.0",
+        "node": ">= 0.12.0"
+      }
+    },
+    "node_modules/collect-v8-coverage": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.3.tgz",
+      "integrity": "sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/create-jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/create-jest/-/create-jest-29.7.0.tgz",
+      "integrity": "sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.9",
+        "jest-config": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "prompts": "^2.0.1"
+      },
+      "bin": {
+        "create-jest": "bin/create-jest.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
+    },
+    "node_modules/dedent": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.1.tgz",
+      "integrity": "sha512-9JmrhGZpOlEgOLdQgSm0zxFaYoQon408V1v49aqTWuXENVlnCuY9JBZcXZiCsZQWDjTm5Qf/nIvAy77mXDAjEg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "babel-plugin-macros": "^3.1.0"
+      },
+      "peerDependenciesMeta": {
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/detect-newline": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
+      "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/diff-sequences": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.286",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.286.tgz",
+      "integrity": "sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/emittery": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.13.1.tgz",
+      "integrity": "sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/emittery?sponsor=1"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
+    },
+    "node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/exit": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+      "integrity": "sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/expect": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/expect-utils": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/fast-equals": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.4.0.tgz",
+      "integrity": "sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fb-watchman": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
+      "integrity": "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bser": "2.1.1"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-package-type": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
+      "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/handlebars": {
+      "version": "4.7.8",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
+      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.2",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
+    "node_modules/import-local": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
+      "integrity": "sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pkg-dir": "^4.2.0",
+        "resolve-cwd": "^3.0.0"
+      },
+      "bin": {
+        "import-local-fixture": "fixtures/cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-generator-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
+      "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-instrument": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
+      "integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/core": "^7.23.9",
+        "@babel/parser": "^7.23.9",
+        "@istanbuljs/schema": "^0.1.3",
+        "istanbul-lib-coverage": "^3.2.0",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-instrument/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
+      "integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
+      "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/core": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "import-local": "^3.0.2",
+        "jest-cli": "^29.7.0"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-changed-files": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-29.7.0.tgz",
+      "integrity": "sha512-fEArFiwf1BpQ+4bXSprcDc3/x4HSzL4al2tozwVpDFpsxALjLYdyiIK4e5Vz66GQJIbXJ82+35PtysofptNX2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "execa": "^5.0.0",
+        "jest-util": "^29.7.0",
+        "p-limit": "^3.1.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-circus": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.7.0.tgz",
+      "integrity": "sha512-3E1nCMgipcTkCocFwM90XXQab9bS+GMsjdpmPrlelaxwD93Ad8iVEjX/vvHPdLPnFf+L40u+5+iutRdA1N9myw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/expect": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "co": "^4.6.0",
+        "dedent": "^1.0.0",
+        "is-generator-fn": "^2.0.0",
+        "jest-each": "^29.7.0",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "p-limit": "^3.1.0",
+        "pretty-format": "^29.7.0",
+        "pure-rand": "^6.0.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-cli": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.7.0.tgz",
+      "integrity": "sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/core": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "create-jest": "^29.7.0",
+        "exit": "^0.1.2",
+        "import-local": "^3.0.2",
+        "jest-config": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "yargs": "^17.3.1"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-config": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.7.0.tgz",
+      "integrity": "sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@jest/test-sequencer": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "babel-jest": "^29.7.0",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "deepmerge": "^4.2.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "jest-circus": "^29.7.0",
+        "jest-environment-node": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-runner": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "parse-json": "^5.2.0",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@types/node": "*",
+        "ts-node": ">=9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "ts-node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-diff": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
+      "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^29.6.3",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-docblock": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.7.0.tgz",
+      "integrity": "sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-each": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.7.0.tgz",
+      "integrity": "sha512-gns+Er14+ZrEoC5fhOfYCY1LOHHr0TI+rQUHZS8Ttw2l7gl+80eHc/gFf2Ktkw0+SIACDTeWvpFcv3B04VembQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "jest-get-type": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-environment-node": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.7.0.tgz",
+      "integrity": "sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "jest-mock": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-get-type": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
+      "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-haste-map": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
+      "integrity": "sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/graceful-fs": "^4.1.3",
+        "@types/node": "*",
+        "anymatch": "^3.0.3",
+        "fb-watchman": "^2.0.0",
+        "graceful-fs": "^4.2.9",
+        "jest-regex-util": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "walker": "^1.0.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "^2.3.2"
+      }
+    },
+    "node_modules/jest-leak-detector": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz",
+      "integrity": "sha512-kYA8IJcSYtST2BY9I+SMC32nDpBT3J2NvWJx8+JCuCdl/CR1I4EKUJROiP8XtCcxqgTTBGJNdbB1A8XRKbTetw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
+      "integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "jest-diff": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-message-util": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
+      "integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.12.13",
+        "@jest/types": "^29.6.3",
+        "@types/stack-utils": "^2.0.0",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "micromatch": "^4.0.4",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-mock": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
+      "integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-pnp-resolver": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
+      "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "peerDependencies": {
+        "jest-resolve": "*"
+      },
+      "peerDependenciesMeta": {
+        "jest-resolve": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-regex-util": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
+      "integrity": "sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-resolve": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.7.0.tgz",
+      "integrity": "sha512-IOVhZSrg+UvVAshDSDtHyFCCBUl/Q3AAJv8iZ6ZjnZ74xzvwuzLXid9IIIPgTnY62SJjfuupMKZsZQRsCvxEgA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-pnp-resolver": "^1.2.2",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "resolve": "^1.20.0",
+        "resolve.exports": "^2.0.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-resolve-dependencies": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.7.0.tgz",
+      "integrity": "sha512-un0zD/6qxJ+S0et7WxeI3H5XSe9lTBBR7bOHCHXkKR6luG5mwDDlIzVQ0V5cZCuoTgEdcdwzTghYkTWfubi+nA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-regex-util": "^29.6.3",
+        "jest-snapshot": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-runner": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.7.0.tgz",
+      "integrity": "sha512-fsc4N6cPCAahybGBfTRcq5wFR6fpLznMg47sY5aDpsoejOcVYFb07AHuSnR0liMcPTgBsA3ZJL6kFOjPdoNipQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/environment": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "emittery": "^0.13.1",
+        "graceful-fs": "^4.2.9",
+        "jest-docblock": "^29.7.0",
+        "jest-environment-node": "^29.7.0",
+        "jest-haste-map": "^29.7.0",
+        "jest-leak-detector": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-resolve": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-watcher": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "p-limit": "^3.1.0",
+        "source-map-support": "0.5.13"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-runtime": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.7.0.tgz",
+      "integrity": "sha512-gUnLjgwdGqW7B4LvOIkbKs9WGbn+QLqRQQ9juC6HndeDiezIwhDP+mhMwHWCEcfQ5RUXa6OPnFF8BJh5xegwwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/globals": "^29.7.0",
+        "@jest/source-map": "^29.6.3",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "cjs-module-lexer": "^1.0.0",
+        "collect-v8-coverage": "^1.0.0",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-mock": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-bom": "^4.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-snapshot": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.7.0.tgz",
+      "integrity": "sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@babel/generator": "^7.7.2",
+        "@babel/plugin-syntax-jsx": "^7.7.2",
+        "@babel/plugin-syntax-typescript": "^7.7.2",
+        "@babel/types": "^7.3.3",
+        "@jest/expect-utils": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "babel-preset-current-node-syntax": "^1.0.0",
+        "chalk": "^4.0.0",
+        "expect": "^29.7.0",
+        "graceful-fs": "^4.2.9",
+        "jest-diff": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "natural-compare": "^1.4.0",
+        "pretty-format": "^29.7.0",
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-snapshot/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/jest-util": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
+      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "graceful-fs": "^4.2.9",
+        "picomatch": "^2.2.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-validate": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.7.0.tgz",
+      "integrity": "sha512-ZB7wHqaRGVw/9hST/OuFUReG7M8vKeq0/J2egIGLdvjHCmYqGARhzXmtgi+gVeZ5uXFF219aOc3Ls2yLg27tkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "camelcase": "^6.2.0",
+        "chalk": "^4.0.0",
+        "jest-get-type": "^29.6.3",
+        "leven": "^3.1.0",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-validate/node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-watcher": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.7.0.tgz",
+      "integrity": "sha512-49Fg7WXkU3Vl2h6LbLtMQ/HyB6rXSIX7SqvBLQmssRBGN9I0PNvPmAmCWSOY6SOvrjhI/F7/bGAv9RtnsPA03g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.0.0",
+        "emittery": "^0.13.1",
+        "jest-util": "^29.7.0",
+        "string-length": "^4.0.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-worker": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
+      "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "jest-util": "^29.7.0",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-worker/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/leven": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+      "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.memoize": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+      "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/makeerror": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
+      "integrity": "sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tmpl": "1.0.5"
+      }
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-int64": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+      "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.27",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
+      "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-locate/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/pkg-dir": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/prompts": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^3.0.3",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
+    "node_modules/pure-rand": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
+      "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "license": "MIT"
+    },
+    "node_modules/react-refresh": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-smooth": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.4.tgz",
+      "integrity": "sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-equals": "^5.0.1",
+        "prop-types": "^15.8.1",
+        "react-transition-group": "^4.4.5"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/react-transition-group": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0",
+        "react-dom": ">=16.6.0"
+      }
+    },
+    "node_modules/recharts": {
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.15.4.tgz",
+      "integrity": "sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.0.0",
+        "eventemitter3": "^4.0.1",
+        "lodash": "^4.17.21",
+        "react-is": "^18.3.1",
+        "react-smooth": "^4.0.4",
+        "recharts-scale": "^0.4.4",
+        "tiny-invariant": "^1.3.1",
+        "victory-vendor": "^36.6.8"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/recharts-scale": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/recharts-scale/-/recharts-scale-0.4.5.tgz",
+      "integrity": "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==",
+      "license": "MIT",
+      "dependencies": {
+        "decimal.js-light": "^2.4.1"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.11",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
+      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-cwd": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+      "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/resolve.exports": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.3.tgz",
+      "integrity": "sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.57.1.tgz",
+      "integrity": "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.57.1",
+        "@rollup/rollup-android-arm64": "4.57.1",
+        "@rollup/rollup-darwin-arm64": "4.57.1",
+        "@rollup/rollup-darwin-x64": "4.57.1",
+        "@rollup/rollup-freebsd-arm64": "4.57.1",
+        "@rollup/rollup-freebsd-x64": "4.57.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.57.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.57.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.57.1",
+        "@rollup/rollup-linux-arm64-musl": "4.57.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.57.1",
+        "@rollup/rollup-linux-loong64-musl": "4.57.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.57.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.57.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.57.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.57.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.57.1",
+        "@rollup/rollup-linux-x64-gnu": "4.57.1",
+        "@rollup/rollup-linux-x64-musl": "4.57.1",
+        "@rollup/rollup-openbsd-x64": "4.57.1",
+        "@rollup/rollup-openharmony-arm64": "4.57.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.57.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.57.1",
+        "@rollup/rollup-win32-x64-gnu": "4.57.1",
+        "@rollup/rollup-win32-x64-msvc": "4.57.1",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+      "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/stack-utils": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+      "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/string-length": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
+      "integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "char-regex": "^1.0.2",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-bom": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+      "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+      "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^7.1.4",
+        "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
+    "node_modules/tmpl": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
+      "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/ts-jest": {
+      "version": "29.4.6",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.6.tgz",
+      "integrity": "sha512-fSpWtOO/1AjSNQguk43hb/JCo16oJDnMJf3CdEGNkqsEX3t0KX96xvyX1D7PfLCpVoKu4MfVrqUkFyblYoY4lA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bs-logger": "^0.2.6",
+        "fast-json-stable-stringify": "^2.1.0",
+        "handlebars": "^4.7.8",
+        "json5": "^2.2.3",
+        "lodash.memoize": "^4.1.2",
+        "make-error": "^1.3.6",
+        "semver": "^7.7.3",
+        "type-fest": "^4.41.0",
+        "yargs-parser": "^21.1.1"
+      },
+      "bin": {
+        "ts-jest": "cli.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || ^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": ">=7.0.0-beta.0 <8",
+        "@jest/transform": "^29.0.0 || ^30.0.0",
+        "@jest/types": "^29.0.0 || ^30.0.0",
+        "babel-jest": "^29.0.0 || ^30.0.0",
+        "jest": "^29.0.0 || ^30.0.0",
+        "jest-util": "^29.0.0 || ^30.0.0",
+        "typescript": ">=4.3 <6"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "@jest/transform": {
+          "optional": true
+        },
+        "@jest/types": {
+          "optional": true
+        },
+        "babel-jest": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jest-util": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-jest/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ts-jest/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/uglify-js": {
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/v8-to-istanbul": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
+      "integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.12",
+        "@types/istanbul-lib-coverage": "^2.0.1",
+        "convert-source-map": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.9.2.tgz",
+      "integrity": "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/walker": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
+      "integrity": "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "makeerror": "1.0.12"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/write-file-atomic": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
+      "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^3.0.7"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "calibrateme",
+  "version": "1.0.0",
+  "description": "Calibration-aware adaptive learning system",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview",
+    "test": "jest --config jest.config.cjs",
+    "test:watch": "jest --config jest.config.cjs --watch",
+    "test:coverage": "jest --config jest.config.cjs --coverage"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "recharts": "^2.10.0",
+    "zustand": "^4.4.0"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.0",
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
+    "@vitejs/plugin-react": "^4.2.0",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.0",
+    "typescript": "^5.3.0",
+    "vite": "^5.0.0"
+  }
+}

--- a/src/App.css
+++ b/src/App.css
@@ -1,0 +1,278 @@
+.app {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.app-header {
+  background: linear-gradient(135deg, #1a365d 0%, #2c5282 100%);
+  color: white;
+  padding: 1.5rem 2rem;
+  text-align: center;
+}
+
+.app-header h1 {
+  margin: 0;
+  font-size: 2rem;
+}
+
+.app-header p {
+  margin: 0.5rem 0 0;
+  opacity: 0.9;
+  font-size: 1rem;
+}
+
+.app-main {
+  flex: 1;
+  padding: 2rem;
+  max-width: 1400px;
+  margin: 0 auto;
+  width: 100%;
+}
+
+.app-footer {
+  background: #2d3748;
+  color: #a0aec0;
+  text-align: center;
+  padding: 1rem;
+  font-size: 0.875rem;
+}
+
+/* Dashboard Layout */
+.dashboard {
+  display: grid;
+  grid-template-columns: 300px 1fr;
+  gap: 1.5rem;
+}
+
+.dashboard-sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.dashboard-content {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+/* Card Component */
+.card {
+  background: white;
+  border-radius: 8px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  padding: 1.25rem;
+}
+
+.card-title {
+  font-size: 1rem;
+  font-weight: 600;
+  color: #2d3748;
+  margin: 0 0 1rem;
+  padding-bottom: 0.75rem;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+/* Form Elements */
+.form-group {
+  margin-bottom: 1rem;
+}
+
+.form-label {
+  display: block;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: #4a5568;
+  margin-bottom: 0.375rem;
+}
+
+.form-select,
+.form-input {
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid #e2e8f0;
+  border-radius: 4px;
+  font-size: 0.875rem;
+  color: #2d3748;
+}
+
+.form-select:focus,
+.form-input:focus {
+  outline: none;
+  border-color: #4299e1;
+  box-shadow: 0 0 0 3px rgba(66, 153, 225, 0.15);
+}
+
+/* Buttons */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.625rem 1.25rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  border-radius: 4px;
+  border: none;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.btn-primary {
+  background: #4299e1;
+  color: white;
+}
+
+.btn-primary:hover {
+  background: #3182ce;
+}
+
+.btn-primary:disabled {
+  background: #a0aec0;
+  cursor: not-allowed;
+}
+
+.btn-secondary {
+  background: #edf2f7;
+  color: #4a5568;
+}
+
+.btn-secondary:hover {
+  background: #e2e8f0;
+}
+
+.btn-block {
+  width: 100%;
+}
+
+/* Metrics Grid */
+.metrics-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+}
+
+.metric-card {
+  background: white;
+  border-radius: 8px;
+  padding: 1rem;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+}
+
+.metric-label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #718096;
+  margin-bottom: 0.25rem;
+}
+
+.metric-value {
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: #2d3748;
+}
+
+.metric-value.positive {
+  color: #38a169;
+}
+
+.metric-value.negative {
+  color: #e53e3e;
+}
+
+/* Charts */
+.chart-container {
+  background: white;
+  border-radius: 8px;
+  padding: 1.25rem;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+}
+
+.chart-title {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: #4a5568;
+  margin-bottom: 1rem;
+}
+
+/* Response Table */
+.response-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.875rem;
+}
+
+.response-table th,
+.response-table td {
+  padding: 0.5rem 0.75rem;
+  text-align: left;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.response-table th {
+  font-weight: 600;
+  color: #4a5568;
+  background: #f7fafc;
+}
+
+.response-table tr:hover {
+  background: #f7fafc;
+}
+
+/* Status Badges */
+.badge {
+  display: inline-block;
+  padding: 0.125rem 0.5rem;
+  border-radius: 9999px;
+  font-size: 0.75rem;
+  font-weight: 500;
+}
+
+.badge-success {
+  background: #c6f6d5;
+  color: #22543d;
+}
+
+.badge-error {
+  background: #fed7d7;
+  color: #822727;
+}
+
+.badge-warning {
+  background: #fefcbf;
+  color: #744210;
+}
+
+.badge-info {
+  background: #bee3f8;
+  color: #2a4365;
+}
+
+/* Loading Spinner */
+.spinner {
+  display: inline-block;
+  width: 1.5rem;
+  height: 1.5rem;
+  border: 2px solid #e2e8f0;
+  border-top-color: #4299e1;
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .dashboard {
+    grid-template-columns: 1fr;
+  }
+
+  .metrics-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import Dashboard from './components/Dashboard';
+import './App.css';
+
+function App() {
+  return (
+    <div className="app">
+      <header className="app-header">
+        <h1>CalibrateMe</h1>
+        <p>Metacognitive Calibration in Adaptive Learning</p>
+      </header>
+      <main className="app-main">
+        <Dashboard />
+      </main>
+      <footer className="app-footer">
+        <p>CS 6795 - Cognitive Science | Georgia Tech | Spring 2026</p>
+      </footer>
+    </div>
+  );
+}
+
+export default App;

--- a/src/baselines/bktOnly.ts
+++ b/src/baselines/bktOnly.ts
@@ -1,0 +1,68 @@
+// =============================================================================
+// BKT-Only Baseline Scheduler
+// Uses Bayesian Knowledge Tracing without calibration adjustment
+// =============================================================================
+
+import { Response, SystemBelief, SimulationConfig } from '../types';
+import { updateBelief } from '../bkt/beliefUpdateEngine';
+import { baseInterval } from '../scheduler/calibrationAwareScheduler';
+
+/**
+ * BKT-Only Scheduler
+ * Schedules based on K̂ only, ignoring calibration
+ */
+export class BKTOnlyScheduler {
+  private beliefs: Map<string, SystemBelief>;
+  private lambda: number;
+  private config: SimulationConfig;
+
+  constructor(lambda: number, config: SimulationConfig) {
+    this.beliefs = new Map();
+    this.lambda = lambda;
+    this.config = config;
+  }
+
+  /**
+   * Get or initialize belief for an item
+   */
+  getBelief(itemId: string): SystemBelief {
+    if (!this.beliefs.has(itemId)) {
+      this.beliefs.set(itemId, {
+        K_hat: 0.3, // Initial belief
+        beta_hat: 0, // Ignored in BKT-only
+        confidence_interval: 0.2,
+        last_updated: new Date(),
+      });
+    }
+    return this.beliefs.get(itemId)!;
+  }
+
+  /**
+   * Process a response and schedule next review
+   */
+  processResponse(response: Response): { nextReview: Date; interval: number } {
+    const currentBelief = this.getBelief(response.item_id);
+
+    // Update belief using BKT
+    const updatedBelief = updateBelief(response, currentBelief, this.config);
+    this.beliefs.set(response.item_id, updatedBelief);
+
+    // Calculate interval based on K̂ only (no calibration adjustment)
+    const interval = baseInterval(updatedBelief.K_hat, this.lambda);
+
+    const nextReview = new Date();
+    nextReview.setDate(nextReview.getDate() + Math.round(interval));
+
+    return {
+      nextReview,
+      interval: Math.round(interval),
+    };
+  }
+
+  /**
+   * Reset scheduler state
+   */
+  reset(): void {
+    this.beliefs.clear();
+  }
+}

--- a/src/baselines/decayBased.ts
+++ b/src/baselines/decayBased.ts
@@ -1,0 +1,91 @@
+// =============================================================================
+// Decay-Based Baseline Scheduler
+// Simple exponential decay scheduler (ignores calibration)
+// =============================================================================
+
+import { Response } from '../types';
+
+/**
+ * Decay-Based Scheduler State
+ */
+export interface DecayState {
+  interval: number;       // Current interval in days
+  lastReview: Date | null;
+  streak: number;         // Consecutive correct answers
+}
+
+/**
+ * Initialize decay state for a new item
+ */
+export function initDecayState(): DecayState {
+  return {
+    interval: 1,
+    lastReview: null,
+    streak: 0,
+  };
+}
+
+/**
+ * Decay-Based Scheduler
+ * Simple: double interval on correct, reset on incorrect
+ */
+export class DecayBasedScheduler {
+  private states: Map<string, DecayState>;
+  private maxInterval: number;
+
+  constructor(maxInterval: number = 30) {
+    this.states = new Map();
+    this.maxInterval = maxInterval;
+  }
+
+  /**
+   * Get or initialize state for an item
+   */
+  getState(itemId: string): DecayState {
+    if (!this.states.has(itemId)) {
+      this.states.set(itemId, initDecayState());
+    }
+    return this.states.get(itemId)!;
+  }
+
+  /**
+   * Process a response and schedule next review
+   */
+  processResponse(response: Response): { nextReview: Date; interval: number } {
+    const state = this.getState(response.item_id);
+
+    let newInterval: number;
+    let newStreak: number;
+
+    if (response.correctness) {
+      // Double the interval (exponential growth)
+      newStreak = state.streak + 1;
+      newInterval = Math.min(state.interval * 2, this.maxInterval);
+    } else {
+      // Reset on error
+      newStreak = 0;
+      newInterval = 1;
+    }
+
+    this.states.set(response.item_id, {
+      interval: newInterval,
+      lastReview: new Date(),
+      streak: newStreak,
+    });
+
+    const nextReview = new Date();
+    nextReview.setDate(nextReview.getDate() + newInterval);
+
+    return {
+      nextReview,
+      interval: newInterval,
+    };
+  }
+
+  /**
+   * Reset scheduler state
+   */
+  reset(): void {
+    this.states.clear();
+  }
+}

--- a/src/baselines/sm2.ts
+++ b/src/baselines/sm2.ts
@@ -1,0 +1,121 @@
+// =============================================================================
+// SM-2 Baseline Scheduler
+// Classic SuperMemo 2 algorithm (calibration-blind)
+// =============================================================================
+
+import { Response } from '../types';
+
+/**
+ * SM-2 Algorithm State for an item
+ */
+export interface SM2State {
+  easeFactor: number;    // EF (starts at 2.5)
+  interval: number;      // Current interval in days
+  repetitions: number;   // Number of successful repetitions
+}
+
+/**
+ * Initialize SM-2 state for a new item
+ */
+export function initSM2State(): SM2State {
+  return {
+    easeFactor: 2.5,
+    interval: 1,
+    repetitions: 0,
+  };
+}
+
+/**
+ * Map confidence and correctness to SM-2 quality rating (0-5)
+ * q = round(5 × c × 1[y=1])
+ * Incorrect responses receive q = 0
+ */
+export function mapToQuality(confidence: number, correctness: boolean): number {
+  if (!correctness) return 0;
+  return Math.round(5 * confidence);
+}
+
+/**
+ * Update SM-2 state based on response quality
+ */
+export function updateSM2(state: SM2State, quality: number): SM2State {
+  // Quality must be in [0, 5]
+  const q = Math.max(0, Math.min(5, quality));
+
+  // Update ease factor
+  let newEF = state.easeFactor + (0.1 - (5 - q) * (0.08 + (5 - q) * 0.02));
+  newEF = Math.max(1.3, newEF); // Minimum EF is 1.3
+
+  let newInterval: number;
+  let newReps: number;
+
+  if (q < 3) {
+    // Failed response - reset
+    newReps = 0;
+    newInterval = 1;
+  } else {
+    // Successful response
+    newReps = state.repetitions + 1;
+
+    if (newReps === 1) {
+      newInterval = 1;
+    } else if (newReps === 2) {
+      newInterval = 6;
+    } else {
+      newInterval = Math.round(state.interval * newEF);
+    }
+  }
+
+  return {
+    easeFactor: newEF,
+    interval: newInterval,
+    repetitions: newReps,
+  };
+}
+
+/**
+ * SM-2 Scheduler
+ */
+export class SM2Scheduler {
+  private states: Map<string, SM2State>;
+
+  constructor() {
+    this.states = new Map();
+  }
+
+  /**
+   * Get or initialize state for an item
+   */
+  getState(itemId: string): SM2State {
+    if (!this.states.has(itemId)) {
+      this.states.set(itemId, initSM2State());
+    }
+    return this.states.get(itemId)!;
+  }
+
+  /**
+   * Process a response and schedule next review
+   */
+  processResponse(response: Response): { nextReview: Date; interval: number } {
+    const state = this.getState(response.item_id);
+    const quality = mapToQuality(response.confidence, response.correctness);
+    const newState = updateSM2(state, quality);
+
+    this.states.set(response.item_id, newState);
+
+    const nextReview = new Date();
+    nextReview.setDate(nextReview.getDate() + newState.interval);
+
+    return {
+      nextReview,
+      interval: newState.interval,
+    };
+  }
+
+  /**
+   * Reset scheduler state
+   */
+  reset(): void {
+    this.states.clear();
+  }
+}

--- a/src/bkt/beliefUpdateEngine.ts
+++ b/src/bkt/beliefUpdateEngine.ts
@@ -1,0 +1,150 @@
+// =============================================================================
+// Bayesian Knowledge Tracing Belief Update Engine
+// Implements Equation 1 from the project pitch
+// =============================================================================
+
+import { Response, SystemBelief, SimulationConfig } from '../types';
+import { clip } from '../utils/random';
+
+/**
+ * Calculate likelihood of correctness given knowledge estimate
+ * P(y|K̂) using slip-guess model
+ */
+export function likelihoodCorrectness(
+  y: boolean,
+  K_hat: number,
+  slip: number,
+  guess: number
+): number {
+  const p_correct = (1 - slip) * K_hat + guess * (1 - K_hat);
+  return y ? p_correct : (1 - p_correct);
+}
+
+/**
+ * Calculate likelihood of confidence given knowledge estimate
+ * P(c|K̂) assuming c ~ N(K̂ + β̂, σ²)
+ */
+export function likelihoodConfidence(
+  c: number,
+  K_hat: number,
+  beta_hat: number,
+  sigma: number
+): number {
+  const expected_c = K_hat + beta_hat;
+  const z = (c - expected_c) / sigma;
+  // Gaussian PDF (unnormalized is fine for Bayes)
+  return Math.exp(-0.5 * z * z);
+}
+
+/**
+ * Calculate likelihood of response time given knowledge estimate
+ * P(τ|K̂) assuming RT decreases with knowledge
+ */
+export function likelihoodRT(
+  tau: number,
+  K_hat: number,
+  tau_base: number,
+  gamma: number,
+  sigma: number
+): number {
+  const expected_tau = tau_base * (1 + gamma * (1 - K_hat));
+  const z = (tau - expected_tau) / sigma;
+  return Math.exp(-0.5 * z * z);
+}
+
+/**
+ * Perform Bayesian belief update (Equation 1)
+ * P(K̂|y,c,τ) ∝ P(y|K̂) × P(c|K̂) × P(τ|K̂) × P(K̂)
+ *
+ * Uses grid approximation for tractability
+ */
+export function updateBelief(
+  response: Response,
+  current_belief: SystemBelief,
+  config: SimulationConfig,
+  grid_points: number = 101
+): SystemBelief {
+  const { slip_probability, guess_probability, confidence_noise_std, rt_noise_std, rt_base, rt_gamma } = config;
+
+  // Create grid of K̂ values
+  const K_values: number[] = [];
+  const posteriors: number[] = [];
+
+  for (let i = 0; i < grid_points; i++) {
+    const K = i / (grid_points - 1);
+    K_values.push(K);
+
+    // Prior: peaked at current belief
+    const prior = Math.exp(-0.5 * ((K - current_belief.K_hat) / 0.2) ** 2);
+
+    // Likelihoods
+    const L_y = likelihoodCorrectness(response.correctness, K, slip_probability, guess_probability);
+    const L_c = likelihoodConfidence(response.confidence, K, current_belief.beta_hat, confidence_noise_std);
+    const L_tau = likelihoodRT(response.response_time, K, rt_base, rt_gamma, rt_noise_std);
+
+    // Posterior (unnormalized)
+    posteriors.push(prior * L_y * L_c * L_tau);
+  }
+
+  // Normalize
+  const sum = posteriors.reduce((a, b) => a + b, 0);
+  const normalized = posteriors.map(p => p / sum);
+
+  // Compute expected value of K̂
+  let K_hat_new = 0;
+  for (let i = 0; i < grid_points; i++) {
+    K_hat_new += K_values[i] * normalized[i];
+  }
+
+  // Compute variance for confidence interval
+  let variance = 0;
+  for (let i = 0; i < grid_points; i++) {
+    variance += (K_values[i] - K_hat_new) ** 2 * normalized[i];
+  }
+
+  return {
+    K_hat: clip(K_hat_new, 0, 1),
+    beta_hat: current_belief.beta_hat, // Updated separately
+    confidence_interval: Math.sqrt(variance) * 1.96,
+    last_updated: new Date(),
+  };
+}
+
+/**
+ * Update beta_hat estimate based on recent responses
+ */
+export function updateBetaHat(
+  responses: Response[],
+  current_beta_hat: number,
+  learning_rate: number = 0.1
+): number {
+  if (responses.length === 0) return current_beta_hat;
+
+  // Calculate recent calibration gap
+  const recent = responses.slice(-10); // Last 10 responses
+  const mean_conf = recent.reduce((s, r) => s + r.confidence, 0) / recent.length;
+  const mean_acc = recent.reduce((s, r) => s + (r.correctness ? 1 : 0), 0) / recent.length;
+  const observed_beta = mean_conf - mean_acc;
+
+  // Exponential moving average
+  return current_beta_hat + learning_rate * (observed_beta - current_beta_hat);
+}
+
+/**
+ * Apply forgetting drift to belief between sessions
+ */
+export function applyBeliefDrift(
+  belief: SystemBelief,
+  lambda: number,
+  days_elapsed: number
+): SystemBelief {
+  // Belief drifts toward uncertainty (0.5) over time
+  const decay = Math.exp(-lambda * days_elapsed);
+  const K_hat_drifted = belief.K_hat * decay + 0.5 * (1 - decay);
+
+  return {
+    ...belief,
+    K_hat: K_hat_drifted,
+    confidence_interval: belief.confidence_interval * (1 + 0.1 * days_elapsed), // Uncertainty grows
+  };
+}

--- a/src/calibration/scoringModule.ts
+++ b/src/calibration/scoringModule.ts
@@ -1,0 +1,161 @@
+// =============================================================================
+// Calibration Scoring Module
+// Implements ECE, Brier Score, and calibration detection
+// =============================================================================
+
+import {
+  Response,
+  CalibrationMetrics,
+  CalibrationBin,
+  CalibrationType,
+} from '../types';
+import { mean } from '../utils/statistics';
+
+/**
+ * Calculate Brier score for a single response
+ * Brier Score = (confidence - correctness)²
+ */
+export function brierScore(confidence: number, correctness: boolean): number {
+  const outcome = correctness ? 1 : 0;
+  return (confidence - outcome) ** 2;
+}
+
+/**
+ * Calculate aggregate Brier score over multiple responses
+ */
+export function aggregateBrierScore(responses: Response[]): number {
+  if (responses.length === 0) return 0;
+  const scores = responses.map(r => brierScore(r.confidence, r.correctness));
+  return mean(scores);
+}
+
+/**
+ * Bin responses by confidence level for ECE calculation
+ */
+export function binResponses(
+  responses: Response[],
+  numBins: number = 10
+): CalibrationBin[] {
+  const bins: CalibrationBin[] = [];
+  const binWidth = 1 / numBins;
+
+  for (let i = 0; i < numBins; i++) {
+    const binStart = i * binWidth;
+    const binEnd = (i + 1) * binWidth;
+
+    const binResponses = responses.filter(
+      r => r.confidence >= binStart && r.confidence < binEnd
+    );
+
+    if (binResponses.length > 0) {
+      const meanConfidence = mean(binResponses.map(r => r.confidence));
+      const meanAccuracy = mean(binResponses.map(r => r.correctness ? 1 : 0));
+
+      bins.push({
+        bin_start: binStart,
+        bin_end: binEnd,
+        mean_confidence: meanConfidence,
+        mean_accuracy: meanAccuracy,
+        count: binResponses.length,
+        calibration_gap: meanAccuracy - meanConfidence,
+      });
+    }
+  }
+
+  return bins;
+}
+
+/**
+ * Calculate Expected Calibration Error (ECE)
+ * ECE = Σ (|bin_size|/n) × |accuracy(bin) - mean_confidence(bin)|
+ */
+export function expectedCalibrationError(
+  responses: Response[],
+  numBins: number = 10
+): number {
+  if (responses.length === 0) return 0;
+
+  const bins = binResponses(responses, numBins);
+  const n = responses.length;
+
+  let ece = 0;
+  for (const bin of bins) {
+    const weight = bin.count / n;
+    const gap = Math.abs(bin.mean_accuracy - bin.mean_confidence);
+    ece += weight * gap;
+  }
+
+  return ece;
+}
+
+/**
+ * Calculate Maximum Calibration Error (MCE)
+ */
+export function maximumCalibrationError(
+  responses: Response[],
+  numBins: number = 10
+): number {
+  if (responses.length === 0) return 0;
+
+  const bins = binResponses(responses, numBins);
+
+  let mce = 0;
+  for (const bin of bins) {
+    const gap = Math.abs(bin.mean_accuracy - bin.mean_confidence);
+    mce = Math.max(mce, gap);
+  }
+
+  return mce;
+}
+
+/**
+ * Detect miscalibration direction from responses
+ */
+export function detectMiscalibration(
+  responses: Response[],
+  threshold: number = 0.05
+): CalibrationType {
+  if (responses.length === 0) return CalibrationType.WELL_CALIBRATED;
+
+  // Calculate mean confidence - mean accuracy
+  const meanConfidence = mean(responses.map(r => r.confidence));
+  const meanAccuracy = mean(responses.map(r => r.correctness ? 1 : 0));
+  const gap = meanConfidence - meanAccuracy;
+
+  if (gap > threshold) {
+    return CalibrationType.OVERCONFIDENT;
+  } else if (gap < -threshold) {
+    return CalibrationType.UNDERCONFIDENT;
+  } else {
+    return CalibrationType.WELL_CALIBRATED;
+  }
+}
+
+/**
+ * Estimate beta_hat (calibration bias) from response history
+ */
+export function estimateBetaHat(responses: Response[]): number {
+  if (responses.length === 0) return 0;
+
+  // β̂ ≈ mean(confidence) - mean(accuracy)
+  const meanConfidence = mean(responses.map(r => r.confidence));
+  const meanAccuracy = mean(responses.map(r => r.correctness ? 1 : 0));
+
+  return meanConfidence - meanAccuracy;
+}
+
+/**
+ * Calculate complete calibration metrics
+ */
+export function calculateCalibrationMetrics(
+  responses: Response[],
+  numBins: number = 10
+): CalibrationMetrics {
+  return {
+    brier_score: aggregateBrierScore(responses),
+    ece: expectedCalibrationError(responses, numBins),
+    mce: maximumCalibrationError(responses, numBins),
+    calibration_direction: detectMiscalibration(responses),
+    bin_data: binResponses(responses, numBins),
+  };
+}

--- a/src/components/CalibrationChart.tsx
+++ b/src/components/CalibrationChart.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from 'recharts';
+
+interface CalibrationChartProps {
+  title: string;
+  data: Array<Record<string, number>>;
+  dataKeys: string[];
+  colors: string[];
+}
+
+const CalibrationChart: React.FC<CalibrationChartProps> = ({
+  title,
+  data,
+  dataKeys,
+  colors,
+}) => {
+  return (
+    <div className="chart-container">
+      <h4 className="chart-title">{title}</h4>
+      <ResponsiveContainer width="100%" height={250}>
+        <LineChart data={data} margin={{ top: 5, right: 20, bottom: 5, left: 0 }}>
+          <CartesianGrid strokeDasharray="3 3" stroke="#e2e8f0" />
+          <XAxis
+            dataKey="session"
+            tick={{ fontSize: 12 }}
+            tickLine={false}
+          />
+          <YAxis
+            domain={[0, 1]}
+            tick={{ fontSize: 12 }}
+            tickLine={false}
+            tickFormatter={(v) => v.toFixed(1)}
+          />
+          <Tooltip
+            contentStyle={{
+              background: 'white',
+              border: '1px solid #e2e8f0',
+              borderRadius: '4px',
+              fontSize: '12px',
+            }}
+          />
+          <Legend />
+          {dataKeys.map((key, index) => (
+            <Line
+              key={key}
+              type="monotone"
+              dataKey={key}
+              stroke={colors[index]}
+              strokeWidth={2}
+              dot={false}
+            />
+          ))}
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  );
+};
+
+export default CalibrationChart;

--- a/src/components/CalibrationCurve.tsx
+++ b/src/components/CalibrationCurve.tsx
@@ -1,0 +1,157 @@
+// =============================================================================
+// Calibration Curve Component
+// Shows confidence vs accuracy with diagonal reference line
+// =============================================================================
+
+import React, { useMemo } from 'react';
+import {
+  ScatterChart,
+  Scatter,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  Legend,
+  Line,
+  ComposedChart,
+  Area,
+} from 'recharts';
+import { CalibrationBin } from '../types';
+
+interface CalibrationCurveProps {
+  bins: CalibrationBin[];
+  title?: string;
+  showRegions?: boolean;
+}
+
+const CalibrationCurve: React.FC<CalibrationCurveProps> = ({
+  bins,
+  title = 'Calibration Curve',
+  showRegions = true,
+}) => {
+  // Prepare data for the chart
+  const chartData = useMemo(() => {
+    return bins.map(bin => ({
+      confidence: bin.mean_confidence,
+      accuracy: bin.mean_accuracy,
+      count: bin.count,
+      gap: bin.calibration_gap,
+    }));
+  }, [bins]);
+
+  // Perfect calibration line data
+  const perfectLine = [
+    { confidence: 0, accuracy: 0 },
+    { confidence: 1, accuracy: 1 },
+  ];
+
+  // Custom tooltip
+  const CustomTooltip = ({ active, payload }: any) => {
+    if (active && payload && payload.length) {
+      const data = payload[0].payload;
+      return (
+        <div style={{
+          background: 'white',
+          border: '1px solid #e2e8f0',
+          borderRadius: '4px',
+          padding: '8px 12px',
+          fontSize: '12px',
+        }}>
+          <p><strong>Confidence:</strong> {(data.confidence * 100).toFixed(0)}%</p>
+          <p><strong>Accuracy:</strong> {(data.accuracy * 100).toFixed(0)}%</p>
+          <p><strong>Gap:</strong> {(data.gap * 100).toFixed(1)}%</p>
+          <p><strong>Responses:</strong> {data.count}</p>
+        </div>
+      );
+    }
+    return null;
+  };
+
+  return (
+    <div className="chart-container">
+      <h4 className="chart-title">{title}</h4>
+      <ResponsiveContainer width="100%" height={300}>
+        <ComposedChart margin={{ top: 20, right: 20, bottom: 20, left: 20 }}>
+          <CartesianGrid strokeDasharray="3 3" stroke="#e2e8f0" />
+          <XAxis
+            type="number"
+            dataKey="confidence"
+            domain={[0, 1]}
+            tickFormatter={(v) => `${(v * 100).toFixed(0)}%`}
+            label={{ value: 'Reported Confidence', position: 'bottom', offset: 0 }}
+          />
+          <YAxis
+            type="number"
+            domain={[0, 1]}
+            tickFormatter={(v) => `${(v * 100).toFixed(0)}%`}
+            label={{ value: 'Actual Accuracy', angle: -90, position: 'insideLeft' }}
+          />
+          <Tooltip content={<CustomTooltip />} />
+
+          {/* Underconfidence region (above diagonal) */}
+          {showRegions && (
+            <Area
+              data={[
+                { confidence: 0, accuracy: 0, upper: 1 },
+                { confidence: 1, accuracy: 1, upper: 1 },
+              ]}
+              dataKey="upper"
+              fill="#c6f6d5"
+              fillOpacity={0.3}
+              stroke="none"
+            />
+          )}
+
+          {/* Perfect calibration line */}
+          <Line
+            data={perfectLine}
+            type="linear"
+            dataKey="accuracy"
+            stroke="#718096"
+            strokeWidth={2}
+            strokeDasharray="5 5"
+            dot={false}
+            name="Perfect Calibration"
+          />
+
+          {/* Actual calibration points */}
+          <Scatter
+            data={chartData}
+            fill="#4299e1"
+            name="Learner Calibration"
+          />
+
+          {/* Connect points with line */}
+          <Line
+            data={chartData}
+            type="monotone"
+            dataKey="accuracy"
+            stroke="#4299e1"
+            strokeWidth={2}
+            dot={{ fill: '#4299e1', r: 6 }}
+            name="Calibration Curve"
+          />
+
+          <Legend />
+        </ComposedChart>
+      </ResponsiveContainer>
+
+      {/* Region labels */}
+      {showRegions && (
+        <div style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          marginTop: '8px',
+          fontSize: '12px',
+          color: '#718096',
+        }}>
+          <span style={{ color: '#38a169' }}>Underconfidence Region</span>
+          <span style={{ color: '#e53e3e' }}>Overconfidence Region</span>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default CalibrationCurve;

--- a/src/components/ComparisonView.tsx
+++ b/src/components/ComparisonView.tsx
@@ -1,0 +1,144 @@
+// =============================================================================
+// Comparison View Component
+// Shows side-by-side comparison of CalibrateMe vs baselines
+// =============================================================================
+
+import React from 'react';
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from 'recharts';
+import { SimulationResults, SchedulerType } from '../types';
+
+interface ComparisonViewProps {
+  results: Map<SchedulerType, SimulationResults>;
+}
+
+const ComparisonView: React.FC<ComparisonViewProps> = ({ results }) => {
+  // Prepare data for charts
+  const retentionData = Array.from(results.entries()).map(([scheduler, result]) => ({
+    name: formatSchedulerName(scheduler),
+    '1-Day': result.retention_1day * 100,
+    '7-Day': result.retention_7day * 100,
+    '30-Day': result.retention_30day * 100,
+  }));
+
+  const efficiencyData = Array.from(results.entries()).map(([scheduler, result]) => ({
+    name: formatSchedulerName(scheduler),
+    'Time to Mastery': result.time_to_mastery,
+    'Review Efficiency': result.review_efficiency,
+  }));
+
+  const calibrationData = Array.from(results.entries()).map(([scheduler, result]) => ({
+    name: formatSchedulerName(scheduler),
+    'Final ECE': result.ece_trajectory[result.ece_trajectory.length - 1] * 100,
+    'Final Brier': result.brier_trajectory[result.brier_trajectory.length - 1] * 100,
+  }));
+
+  return (
+    <div className="comparison-view">
+      <h3 className="card-title">Scheduler Comparison</h3>
+
+      {/* Retention Comparison */}
+      <div className="chart-container" style={{ marginBottom: '1.5rem' }}>
+        <h4 className="chart-title">Retention Rates</h4>
+        <ResponsiveContainer width="100%" height={250}>
+          <BarChart data={retentionData} layout="vertical">
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis type="number" domain={[0, 100]} unit="%" />
+            <YAxis type="category" dataKey="name" width={100} />
+            <Tooltip formatter={(value: number) => `${value.toFixed(1)}%`} />
+            <Legend />
+            <Bar dataKey="1-Day" fill="#38a169" />
+            <Bar dataKey="7-Day" fill="#4299e1" />
+            <Bar dataKey="30-Day" fill="#9f7aea" />
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+
+      {/* Efficiency Comparison */}
+      <div className="chart-container" style={{ marginBottom: '1.5rem' }}>
+        <h4 className="chart-title">Learning Efficiency</h4>
+        <ResponsiveContainer width="100%" height={200}>
+          <BarChart data={efficiencyData}>
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis dataKey="name" />
+            <YAxis />
+            <Tooltip />
+            <Legend />
+            <Bar dataKey="Time to Mastery" fill="#ed8936" name="Sessions to Mastery" />
+            <Bar dataKey="Review Efficiency" fill="#4299e1" name="Reviews per Item" />
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+
+      {/* Calibration Error Comparison */}
+      <div className="chart-container">
+        <h4 className="chart-title">Calibration Error (Lower is Better)</h4>
+        <ResponsiveContainer width="100%" height={200}>
+          <BarChart data={calibrationData}>
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis dataKey="name" />
+            <YAxis domain={[0, 'auto']} />
+            <Tooltip formatter={(value: number) => `${value.toFixed(2)}%`} />
+            <Legend />
+            <Bar dataKey="Final ECE" fill="#e53e3e" name="ECE (%)" />
+            <Bar dataKey="Final Brier" fill="#fc8181" name="Brier (%)" />
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+
+      {/* Summary Table */}
+      <div className="card" style={{ marginTop: '1.5rem' }}>
+        <h4 className="chart-title">Summary Statistics</h4>
+        <table className="response-table">
+          <thead>
+            <tr>
+              <th>Scheduler</th>
+              <th>Ret. (1d)</th>
+              <th>Ret. (7d)</th>
+              <th>Ret. (30d)</th>
+              <th>Mastery</th>
+              <th>Efficiency</th>
+              <th>ECE</th>
+            </tr>
+          </thead>
+          <tbody>
+            {Array.from(results.entries()).map(([scheduler, result]) => {
+              const isBest = scheduler === SchedulerType.CALIBRATEME;
+              return (
+                <tr key={scheduler} style={{ background: isBest ? '#ebf8ff' : undefined }}>
+                  <td><strong>{formatSchedulerName(scheduler)}</strong></td>
+                  <td>{(result.retention_1day * 100).toFixed(1)}%</td>
+                  <td>{(result.retention_7day * 100).toFixed(1)}%</td>
+                  <td>{(result.retention_30day * 100).toFixed(1)}%</td>
+                  <td>{result.time_to_mastery} sessions</td>
+                  <td>{result.review_efficiency.toFixed(2)}</td>
+                  <td>{(result.ece_trajectory[result.ece_trajectory.length - 1] * 100).toFixed(2)}%</td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+};
+
+function formatSchedulerName(scheduler: SchedulerType): string {
+  switch (scheduler) {
+    case SchedulerType.CALIBRATEME: return 'CalibrateMe';
+    case SchedulerType.SM2: return 'SM-2';
+    case SchedulerType.BKT_ONLY: return 'BKT-Only';
+    case SchedulerType.DECAY_BASED: return 'Decay-Based';
+    default: return scheduler;
+  }
+}
+
+export default ComparisonView;

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -1,0 +1,121 @@
+// =============================================================================
+// Dashboard Component (UPDATED)
+// =============================================================================
+
+import React from 'react';
+import { useSimulationStore } from '../store/simulationStore';
+import { calculateCalibrationMetrics } from '../calibration/scoringModule';
+import LearnerProfileSelector from './LearnerProfileSelector';
+import SimulationControls from './SimulationControls';
+import MetricsDisplay from './MetricsDisplay';
+import CalibrationChart from './CalibrationChart';
+import CalibrationCurve from './CalibrationCurve';
+import ComparisonView from './ComparisonView';
+import ResponseHistory from './ResponseHistory';
+import ProgressBar from './ProgressBar';
+
+const Dashboard: React.FC = () => {
+  const {
+    results,
+    comparisonResults,
+    isRunning,
+    error,
+    progress,
+    progressMessage,
+  } = useSimulationStore();
+
+  // Calculate calibration bins from session data for calibration curve
+  const calibrationBins = React.useMemo(() => {
+    if (!results) return [];
+
+    // Aggregate all responses across sessions for binning
+    const mockResponses = results.session_data.flatMap(session => {
+      return Array(session.items_reviewed).fill(null).map((_, i) => ({
+        item_id: `${session.session_number}-${i}`,
+        correctness: i < session.correct_count,
+        confidence: session.mean_confidence + (Math.random() - 0.5) * 0.2,
+        response_time: session.mean_rt,
+        timestamp: new Date(),
+      }));
+    });
+
+    return calculateCalibrationMetrics(mockResponses).bin_data;
+  }, [results]);
+
+  return (
+    <div className="dashboard">
+      <div className="dashboard-sidebar">
+        <LearnerProfileSelector />
+        <SimulationControls />
+      </div>
+
+      <div className="dashboard-content">
+        {error && (
+          <div className="card" style={{ background: '#fed7d7', color: '#822727' }}>
+            <p><strong>Error:</strong> {error}</p>
+          </div>
+        )}
+
+        {isRunning && (
+          <div className="card" style={{ padding: '2rem' }}>
+            <ProgressBar progress={progress} message={progressMessage} />
+          </div>
+        )}
+
+        {/* Single Simulation Results */}
+        {results && !isRunning && !comparisonResults && (
+          <>
+            <MetricsDisplay results={results} />
+
+            <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '1.5rem' }}>
+              <CalibrationChart
+                title="Knowledge Trajectory"
+                data={results.K_star_trajectory.map((k, i) => ({
+                  session: i + 1,
+                  'True (K*)': k,
+                  'Belief (K̂)': results.K_hat_trajectory[i],
+                }))}
+                dataKeys={['True (K*)', 'Belief (K̂)']}
+                colors={['#38a169', '#4299e1']}
+              />
+              <CalibrationChart
+                title="Calibration Error Over Time"
+                data={results.ece_trajectory.map((e, i) => ({
+                  session: i + 1,
+                  ECE: e,
+                  Brier: results.brier_trajectory[i],
+                }))}
+                dataKeys={['ECE', 'Brier']}
+                colors={['#e53e3e', '#ed8936']}
+              />
+            </div>
+
+            {calibrationBins.length > 0 && (
+              <CalibrationCurve
+                bins={calibrationBins}
+                title="Calibration Curve (Confidence vs Accuracy)"
+              />
+            )}
+
+            <ResponseHistory sessionData={results.session_data} />
+          </>
+        )}
+
+        {/* Comparison Results */}
+        {comparisonResults && !isRunning && (
+          <ComparisonView results={comparisonResults} />
+        )}
+
+        {!results && !comparisonResults && !isRunning && !error && (
+          <div className="card" style={{ textAlign: 'center', padding: '3rem', color: '#718096' }}>
+            <h3 style={{ marginBottom: '1rem' }}>Welcome to CalibrateMe</h3>
+            <p>Select a learner profile and click "Run Simulation" to see results.</p>
+            <p>Or click "Compare Schedulers" to compare CalibrateMe against baselines.</p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default Dashboard;

--- a/src/components/HypothesisResults.tsx
+++ b/src/components/HypothesisResults.tsx
@@ -1,0 +1,165 @@
+// =============================================================================
+// Hypothesis Results Component
+// Displays H1, H2, H3 test results
+// =============================================================================
+
+import React from 'react';
+import { SimulationResults, SchedulerType } from '../types';
+import { mean, cohensD } from '../utils/statistics';
+
+interface HypothesisResultsProps {
+  resultsByProfile: Map<string, Map<SchedulerType, SimulationResults[]>>;
+}
+
+interface HypothesisResult {
+  hypothesis: string;
+  description: string;
+  supported: boolean;
+  evidence: string;
+  effectSize: number;
+}
+
+const HypothesisResults: React.FC<HypothesisResultsProps> = ({ resultsByProfile }) => {
+  const hypotheses = analyzeHypotheses(resultsByProfile);
+
+  return (
+    <div className="card">
+      <h3 className="card-title">Hypothesis Test Results</h3>
+
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+        {hypotheses.map((h, index) => (
+          <div
+            key={index}
+            style={{
+              padding: '1rem',
+              borderRadius: '8px',
+              border: '1px solid',
+              borderColor: h.supported ? '#38a169' : '#e53e3e',
+              background: h.supported ? '#f0fff4' : '#fff5f5',
+            }}
+          >
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
+              <div>
+                <h4 style={{ margin: 0, color: h.supported ? '#22543d' : '#742a2a' }}>
+                  {h.hypothesis}
+                </h4>
+                <p style={{ margin: '0.5rem 0', color: '#4a5568', fontSize: '0.875rem' }}>
+                  {h.description}
+                </p>
+              </div>
+              <span
+                className={`badge ${h.supported ? 'badge-success' : 'badge-error'}`}
+                style={{ fontSize: '0.875rem', padding: '0.25rem 0.75rem' }}
+              >
+                {h.supported ? 'Supported' : 'Not Supported'}
+              </span>
+            </div>
+
+            <div style={{ marginTop: '0.75rem', fontSize: '0.875rem', color: '#718096' }}>
+              <p><strong>Evidence:</strong> {h.evidence}</p>
+              <p>
+                <strong>Effect Size (Cohen's d):</strong> {h.effectSize.toFixed(2)}
+                {' '}
+                ({interpretEffectSize(h.effectSize)})
+              </p>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div style={{ marginTop: '1.5rem', padding: '1rem', background: '#f7fafc', borderRadius: '8px' }}>
+        <h4 style={{ margin: '0 0 0.5rem' }}>Summary</h4>
+        <p style={{ margin: 0, fontSize: '0.875rem', color: '#4a5568' }}>
+          {hypotheses.filter(h => h.supported).length} of {hypotheses.length} hypotheses supported.
+        </p>
+      </div>
+    </div>
+  );
+};
+
+function analyzeHypotheses(
+  resultsByProfile: Map<string, Map<SchedulerType, SimulationResults[]>>
+): HypothesisResult[] {
+  const results: HypothesisResult[] = [];
+
+  // Extract improvement metrics for each calibration type
+  const overconfidentImprovement = calculateImprovementForCalibration(resultsByProfile, 'Over');
+  const underconfidentImprovement = calculateImprovementForCalibration(resultsByProfile, 'Under');
+  const wellCalibratedImprovement = calculateImprovementForCalibration(resultsByProfile, 'Well');
+
+  // H1: Overconfident learners show largest improvement
+  const h1Supported = overconfidentImprovement.mean > underconfidentImprovement.mean &&
+                      overconfidentImprovement.mean > wellCalibratedImprovement.mean;
+
+  results.push({
+    hypothesis: 'H1: Overconfident Learners',
+    description: 'Overconfident learners show the largest improvement under CalibrateMe.',
+    supported: h1Supported,
+    evidence: `Improvement: Over=${(overconfidentImprovement.mean * 100).toFixed(1)}%, Under=${(underconfidentImprovement.mean * 100).toFixed(1)}%, Well=${(wellCalibratedImprovement.mean * 100).toFixed(1)}%`,
+    effectSize: overconfidentImprovement.effectSize,
+  });
+
+  // H2: Underconfident learners show moderate improvement
+  const h2Supported = underconfidentImprovement.mean > wellCalibratedImprovement.mean &&
+                      underconfidentImprovement.mean < overconfidentImprovement.mean;
+
+  results.push({
+    hypothesis: 'H2: Underconfident Learners',
+    description: 'Underconfident learners show moderate improvement under CalibrateMe.',
+    supported: h2Supported,
+    evidence: `Moderate improvement of ${(underconfidentImprovement.mean * 100).toFixed(1)}% (between over and well-calibrated)`,
+    effectSize: underconfidentImprovement.effectSize,
+  });
+
+  // H3: Well-calibrated learners show minimal difference
+  const h3Supported = Math.abs(wellCalibratedImprovement.mean) < 0.05; // Less than 5% difference
+
+  results.push({
+    hypothesis: 'H3: Well-Calibrated Learners',
+    description: 'Well-calibrated learners show minimal difference (validating calibration as key variable).',
+    supported: h3Supported,
+    evidence: `Difference of ${(wellCalibratedImprovement.mean * 100).toFixed(1)}% (threshold: <5%)`,
+    effectSize: wellCalibratedImprovement.effectSize,
+  });
+
+  return results;
+}
+
+function calculateImprovementForCalibration(
+  resultsByProfile: Map<string, Map<SchedulerType, SimulationResults[]>>,
+  calibrationType: string
+): { mean: number; effectSize: number } {
+  const calibrateMe: number[] = [];
+  const sm2: number[] = [];
+
+  for (const [profileId, schedulerResults] of resultsByProfile) {
+    if (profileId.includes(calibrationType)) {
+      const cmResults = schedulerResults.get(SchedulerType.CALIBRATEME);
+      const sm2Results = schedulerResults.get(SchedulerType.SM2);
+
+      if (cmResults && sm2Results) {
+        calibrateMe.push(...cmResults.map(r => r.retention_7day));
+        sm2.push(...sm2Results.map(r => r.retention_7day));
+      }
+    }
+  }
+
+  if (calibrateMe.length === 0 || sm2.length === 0) {
+    return { mean: 0, effectSize: 0 };
+  }
+
+  const improvement = mean(calibrateMe) - mean(sm2);
+  const effectSize = cohensD(calibrateMe, sm2);
+
+  return { mean: improvement, effectSize };
+}
+
+function interpretEffectSize(d: number): string {
+  const absD = Math.abs(d);
+  if (absD < 0.2) return 'negligible';
+  if (absD < 0.5) return 'small';
+  if (absD < 0.8) return 'medium';
+  return 'large';
+}
+
+export default HypothesisResults;

--- a/src/components/LearnerProfileSelector.tsx
+++ b/src/components/LearnerProfileSelector.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { useSimulationStore } from '../store/simulationStore';
+import { getAllProfileNames, PROFILE_PARAMS } from '../profiles/learnerProfiles';
+
+const LearnerProfileSelector: React.FC = () => {
+  const { selectedProfile, setSelectedProfile } = useSimulationStore();
+  const profiles = getAllProfileNames();
+  const params = PROFILE_PARAMS[selectedProfile];
+
+  return (
+    <div className="card">
+      <h3 className="card-title">Learner Profile</h3>
+
+      <div className="form-group">
+        <label className="form-label">Select Profile</label>
+        <select
+          className="form-select"
+          value={selectedProfile}
+          onChange={(e) => setSelectedProfile(e.target.value)}
+        >
+          {profiles.map(name => (
+            <option key={name} value={name}>{name}</option>
+          ))}
+        </select>
+      </div>
+
+      {params && (
+        <div style={{ fontSize: '0.875rem', color: '#4a5568' }}>
+          <p><strong>Ability:</strong> {params.ability}</p>
+          <p><strong>Calibration:</strong> {params.calibration}</p>
+          <p><strong>Learning Rate (α):</strong> {params.alpha}</p>
+          <p><strong>Forgetting Rate (λ):</strong> {params.lambda}</p>
+          <p><strong>Calibration Bias (β*):</strong> {params.beta_star > 0 ? '+' : ''}{params.beta_star}</p>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default LearnerProfileSelector;

--- a/src/components/MetricsDisplay.tsx
+++ b/src/components/MetricsDisplay.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { SimulationResults } from '../types';
+
+interface MetricsDisplayProps {
+  results: SimulationResults;
+}
+
+const MetricsDisplay: React.FC<MetricsDisplayProps> = ({ results }) => {
+  const metrics = [
+    {
+      label: 'Retention (1 day)',
+      value: `${(results.retention_1day * 100).toFixed(1)}%`,
+      positive: results.retention_1day > 0.8,
+    },
+    {
+      label: 'Retention (7 days)',
+      value: `${(results.retention_7day * 100).toFixed(1)}%`,
+      positive: results.retention_7day > 0.7,
+    },
+    {
+      label: 'Retention (30 days)',
+      value: `${(results.retention_30day * 100).toFixed(1)}%`,
+      positive: results.retention_30day > 0.6,
+    },
+    {
+      label: 'Time to Mastery',
+      value: `${results.time_to_mastery} sessions`,
+      positive: results.time_to_mastery < results.config.num_sessions,
+    },
+    {
+      label: 'Review Efficiency',
+      value: `${results.review_efficiency.toFixed(2)}`,
+      positive: results.review_efficiency < 5,
+    },
+    {
+      label: 'Final ECE',
+      value: results.ece_trajectory[results.ece_trajectory.length - 1]?.toFixed(3) || 'N/A',
+      positive: (results.ece_trajectory[results.ece_trajectory.length - 1] || 1) < 0.1,
+    },
+  ];
+
+  return (
+    <div className="metrics-grid">
+      {metrics.map((metric, index) => (
+        <div key={index} className="metric-card">
+          <div className="metric-label">{metric.label}</div>
+          <div className={`metric-value ${metric.positive ? 'positive' : ''}`}>
+            {metric.value}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default MetricsDisplay;

--- a/src/components/ProgressBar.tsx
+++ b/src/components/ProgressBar.tsx
@@ -1,0 +1,44 @@
+// =============================================================================
+// Progress Bar Component
+// =============================================================================
+
+import React from 'react';
+
+interface ProgressBarProps {
+  progress: number;
+  message?: string;
+}
+
+const ProgressBar: React.FC<ProgressBarProps> = ({ progress, message }) => {
+  return (
+    <div style={{ width: '100%' }}>
+      <div style={{
+        display: 'flex',
+        justifyContent: 'space-between',
+        marginBottom: '0.5rem',
+        fontSize: '0.875rem',
+        color: '#4a5568',
+      }}>
+        <span>{message || 'Processing...'}</span>
+        <span>{progress.toFixed(0)}%</span>
+      </div>
+      <div style={{
+        width: '100%',
+        height: '8px',
+        background: '#e2e8f0',
+        borderRadius: '4px',
+        overflow: 'hidden',
+      }}>
+        <div style={{
+          width: `${progress}%`,
+          height: '100%',
+          background: 'linear-gradient(90deg, #4299e1, #38b2ac)',
+          borderRadius: '4px',
+          transition: 'width 0.3s ease',
+        }} />
+      </div>
+    </div>
+  );
+};
+
+export default ProgressBar;

--- a/src/components/ResponseHistory.tsx
+++ b/src/components/ResponseHistory.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { SessionData } from '../types';
+
+interface ResponseHistoryProps {
+  sessionData: SessionData[];
+}
+
+const ResponseHistory: React.FC<ResponseHistoryProps> = ({ sessionData }) => {
+  // Show last 10 sessions
+  const recentSessions = sessionData.slice(-10);
+
+  return (
+    <div className="card">
+      <h3 className="card-title">Session History (Last 10)</h3>
+      <div style={{ overflowX: 'auto' }}>
+        <table className="response-table">
+          <thead>
+            <tr>
+              <th>Session</th>
+              <th>Items</th>
+              <th>Correct</th>
+              <th>Accuracy</th>
+              <th>Mean Conf.</th>
+              <th>Type 1</th>
+              <th>Type 2</th>
+              <th>Scaffolds</th>
+              <th>Mean K*</th>
+              <th>ECE</th>
+            </tr>
+          </thead>
+          <tbody>
+            {recentSessions.map((session) => {
+              const accuracy = session.correct_count / session.items_reviewed;
+              return (
+                <tr key={session.session_number}>
+                  <td>{session.session_number + 1}</td>
+                  <td>{session.items_reviewed}</td>
+                  <td>{session.correct_count}</td>
+                  <td>
+                    <span className={`badge ${accuracy > 0.7 ? 'badge-success' : 'badge-warning'}`}>
+                      {(accuracy * 100).toFixed(0)}%
+                    </span>
+                  </td>
+                  <td>{(session.mean_confidence * 100).toFixed(0)}%</td>
+                  <td>{session.type1_count}</td>
+                  <td>{session.type2_count}</td>
+                  <td>{session.scaffolds_delivered}</td>
+                  <td>{session.mean_K_star.toFixed(2)}</td>
+                  <td>{session.ece.toFixed(3)}</td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+};
+
+export default ResponseHistory;

--- a/src/components/SimulationControls.tsx
+++ b/src/components/SimulationControls.tsx
@@ -1,0 +1,132 @@
+// =============================================================================
+// Simulation Controls (UPDATED)
+// =============================================================================
+
+import React from 'react';
+import { useSimulationStore } from '../store/simulationStore';
+import { SchedulerType } from '../types';
+
+const SimulationControls: React.FC = () => {
+  const {
+    config,
+    setConfig,
+    setSchedulerType,
+    runSimulation,
+    runComparison,
+    reset,
+    isRunning
+  } = useSimulationStore();
+
+  return (
+    <div className="card">
+      <h3 className="card-title">Simulation Settings</h3>
+
+      <div className="form-group">
+        <label className="form-label">Scheduler</label>
+        <select
+          className="form-select"
+          value={config.scheduler_type}
+          onChange={(e) => setSchedulerType(e.target.value as SchedulerType)}
+          disabled={isRunning}
+        >
+          <option value={SchedulerType.CALIBRATEME}>CalibrateMe (Full)</option>
+          <option value={SchedulerType.SM2}>SM-2 Baseline</option>
+          <option value={SchedulerType.BKT_ONLY}>BKT-Only</option>
+          <option value={SchedulerType.DECAY_BASED}>Decay-Based</option>
+        </select>
+      </div>
+
+      <div className="form-group">
+        <label className="form-label">Number of Sessions</label>
+        <input
+          type="number"
+          className="form-input"
+          value={config.num_sessions}
+          onChange={(e) => setConfig({ num_sessions: parseInt(e.target.value) || 30 })}
+          min={1}
+          max={100}
+          disabled={isRunning}
+        />
+      </div>
+
+      <div className="form-group">
+        <label className="form-label">Items per Session</label>
+        <input
+          type="number"
+          className="form-input"
+          value={config.items_per_session}
+          onChange={(e) => setConfig({ items_per_session: parseInt(e.target.value) || 20 })}
+          min={1}
+          max={50}
+          disabled={isRunning}
+        />
+      </div>
+
+      <div className="form-group">
+        <label className="form-label">Total Items</label>
+        <input
+          type="number"
+          className="form-input"
+          value={config.num_items}
+          onChange={(e) => setConfig({ num_items: parseInt(e.target.value) || 100 })}
+          min={10}
+          max={500}
+          disabled={isRunning}
+        />
+      </div>
+
+      <div className="form-group">
+        <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', cursor: 'pointer' }}>
+          <input
+            type="checkbox"
+            checked={config.enable_scaffolding}
+            onChange={(e) => setConfig({ enable_scaffolding: e.target.checked })}
+            disabled={isRunning}
+          />
+          <span className="form-label" style={{ margin: 0 }}>Enable Scaffolding</span>
+        </label>
+      </div>
+
+      <div className="form-group">
+        <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', cursor: 'pointer' }}>
+          <input
+            type="checkbox"
+            checked={config.enable_dual_process}
+            onChange={(e) => setConfig({ enable_dual_process: e.target.checked })}
+            disabled={isRunning}
+          />
+          <span className="form-label" style={{ margin: 0 }}>Enable Dual-Process</span>
+        </label>
+      </div>
+
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', marginTop: '1rem' }}>
+        <button
+          className="btn btn-primary btn-block"
+          onClick={runSimulation}
+          disabled={isRunning}
+        >
+          {isRunning ? 'Running...' : 'Run Simulation'}
+        </button>
+
+        <button
+          className="btn btn-secondary btn-block"
+          onClick={runComparison}
+          disabled={isRunning}
+          style={{ background: '#9f7aea', color: 'white' }}
+        >
+          Compare All Schedulers
+        </button>
+
+        <button
+          className="btn btn-secondary btn-block"
+          onClick={reset}
+          disabled={isRunning}
+        >
+          Reset
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default SimulationControls;

--- a/src/dualProcess/classifier.ts
+++ b/src/dualProcess/classifier.ts
@@ -1,0 +1,166 @@
+// =============================================================================
+// Dual-Process Classifier
+// Classifies responses as Type 1 (automatic) or Type 2 (deliberate)
+// =============================================================================
+
+import { Response, ProcessedResponse, ResponseType } from '../types';
+import { OnlineStatistics, zScore } from '../utils/statistics';
+
+/**
+ * Dual-process classifier state (tracks running statistics)
+ */
+export class DualProcessClassifier {
+  private rtStats: OnlineStatistics;
+  private rtByDifficulty: Map<string, OnlineStatistics>;
+
+  // Thresholds for classification
+  private rtThreshold: number;      // Z-score threshold for "fast"
+  private confidenceThreshold: number; // Confidence threshold for "high"
+
+  constructor(
+    rtThreshold: number = -0.5,
+    confidenceThreshold: number = 0.7
+  ) {
+    this.rtStats = new OnlineStatistics();
+    this.rtByDifficulty = new Map();
+    this.rtThreshold = rtThreshold;
+    this.confidenceThreshold = confidenceThreshold;
+  }
+
+  /**
+   * Normalize RT within learner
+   */
+  normalizeRT(tau: number): number {
+    if (this.rtStats.count < 5) {
+      // Not enough data, return 0 (neutral)
+      return 0;
+    }
+    return zScore(tau, this.rtStats.mean, this.rtStats.std);
+  }
+
+  /**
+   * Normalize RT by item difficulty
+   */
+  normalizeRTByDifficulty(tau: number, difficulty_bin: string): number {
+    const stats = this.rtByDifficulty.get(difficulty_bin);
+    if (!stats || stats.count < 3) {
+      return this.normalizeRT(tau);
+    }
+    return zScore(tau, stats.mean, stats.std);
+  }
+
+  /**
+   * Compute dual-process score (RT × confidence interaction)
+   * Higher score = more Type 1 (automatic)
+   */
+  computeDualProcessScore(normalized_rt: number, confidence: number): number {
+    // Fast (negative z-score) + high confidence = positive score (Type 1)
+    // Slow (positive z-score) + low confidence = negative score (Type 2)
+    return confidence - (normalized_rt * 0.5 + 0.5);
+  }
+
+  /**
+   * Classify response type
+   */
+  classifyResponseType(
+    normalized_rt: number,
+    confidence: number,
+    correctness: boolean
+  ): ResponseType {
+    // Only classify correct responses (errors are ambiguous)
+    if (!correctness) {
+      return ResponseType.TYPE2_DELIBERATE; // Default for errors
+    }
+
+    const isFast = normalized_rt < this.rtThreshold;
+    const isHighConfidence = confidence > this.confidenceThreshold;
+
+    if (isFast && isHighConfidence) {
+      return ResponseType.TYPE1_AUTOMATIC;
+    } else {
+      return ResponseType.TYPE2_DELIBERATE;
+    }
+  }
+
+  /**
+   * Get interval multiplier based on response type
+   */
+  getIntervalMultiplier(responseType: ResponseType, correctness: boolean): number {
+    if (!correctness) {
+      return 0.5; // Shorter interval for errors
+    }
+
+    if (responseType === ResponseType.TYPE1_AUTOMATIC) {
+      return 1.2; // Slightly longer interval for automatized responses
+    } else {
+      return 1.0; // Standard interval for deliberate responses
+    }
+  }
+
+  /**
+   * Update running statistics with new response
+   */
+  updateStatistics(response: Response, difficulty_bin: string): void {
+    this.rtStats.update(response.response_time);
+
+    if (!this.rtByDifficulty.has(difficulty_bin)) {
+      this.rtByDifficulty.set(difficulty_bin, new OnlineStatistics());
+    }
+    this.rtByDifficulty.get(difficulty_bin)!.update(response.response_time);
+  }
+
+  /**
+   * Process a response and return enriched version
+   */
+  processResponse(response: Response, difficulty_bin: string): ProcessedResponse {
+    // Update statistics first
+    this.updateStatistics(response, difficulty_bin);
+
+    // Normalize RT
+    const normalized_rt = this.normalizeRTByDifficulty(
+      response.response_time,
+      difficulty_bin
+    );
+
+    // Compute score and classify
+    const dual_process_score = this.computeDualProcessScore(
+      normalized_rt,
+      response.confidence
+    );
+
+    const response_type = this.classifyResponseType(
+      normalized_rt,
+      response.confidence,
+      response.correctness
+    );
+
+    // Calculate Brier score
+    const outcome = response.correctness ? 1 : 0;
+    const brier_score = (response.confidence - outcome) ** 2;
+
+    return {
+      ...response,
+      response_type,
+      normalized_rt,
+      dual_process_score,
+      brier_score,
+    };
+  }
+
+  /**
+   * Reset classifier state
+   */
+  reset(): void {
+    this.rtStats.reset();
+    this.rtByDifficulty.clear();
+  }
+}
+
+/**
+ * Get difficulty bin label for an item
+ */
+export function getDifficultyBin(difficulty: number): string {
+  if (difficulty < 0.33) return 'easy';
+  if (difficulty < 0.67) return 'medium';
+  return 'hard';
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/src/memory/forgettingModel.ts
+++ b/src/memory/forgettingModel.ts
@@ -1,0 +1,119 @@
+// =============================================================================
+// Forgetting Model
+// Implements Equation 3 from the project pitch
+// =============================================================================
+
+import { Item } from '../types';
+
+/**
+ * Apply exponential forgetting to true knowledge (Equation 3)
+ * K*_{t'} = K*_t × e^{-λ × Δt}
+ */
+export function applyForgetting(
+  K_star: number,
+  lambda: number,
+  delta_t: number
+): number {
+  return K_star * Math.exp(-lambda * delta_t);
+}
+
+/**
+ * Calculate days since last review
+ */
+export function daysSinceReview(lastReview: Date | null, now: Date = new Date()): number {
+  if (!lastReview) return 0;
+  const msPerDay = 24 * 60 * 60 * 1000;
+  return (now.getTime() - lastReview.getTime()) / msPerDay;
+}
+
+/**
+ * Predict knowledge at a future time point
+ */
+export function predictForgottenKnowledge(
+  K_star: number,
+  lambda: number,
+  days_in_future: number
+): number {
+  return applyForgetting(K_star, lambda, days_in_future);
+}
+
+/**
+ * Calculate optimal review time (when K* drops to threshold)
+ * Solving: threshold = K* × e^{-λt}
+ * t = -ln(threshold/K*) / λ
+ */
+export function optimalReviewTime(
+  K_star: number,
+  lambda: number,
+  threshold: number = 0.7
+): number {
+  if (K_star <= threshold) return 0; // Review immediately
+  if (lambda === 0) return Infinity;
+
+  return -Math.log(threshold / K_star) / lambda;
+}
+
+/**
+ * Apply forgetting to an item
+ */
+export function applyItemForgetting(
+  item: Item,
+  lambda: number,
+  now: Date = new Date()
+): Item {
+  const delta_t = daysSinceReview(item.true_state.last_review, now);
+
+  if (delta_t === 0) return item;
+
+  return {
+    ...item,
+    true_state: {
+      ...item.true_state,
+      K_star: applyForgetting(item.true_state.K_star, lambda, delta_t),
+    },
+  };
+}
+
+/**
+ * Apply forgetting to all items in a pool
+ */
+export function applyBatchForgetting(
+  items: Item[],
+  lambda: number,
+  now: Date = new Date()
+): Item[] {
+  return items.map(item => applyItemForgetting(item, lambda, now));
+}
+
+/**
+ * Update true knowledge after a learning event (Equation 2)
+ * K*_{t+1} = K*_t + α × (1 - K*_t) × 1[y=1] + α_err × (1 - K*_t) × 1[y=0]
+ */
+export function applyLearning(
+  K_star: number,
+  correctness: boolean,
+  alpha: number,
+  alpha_err: number
+): number {
+  if (correctness) {
+    return K_star + alpha * (1 - K_star);
+  } else {
+    // Learning from errors (smaller effect)
+    return K_star + alpha_err * (1 - K_star);
+  }
+}
+
+/**
+ * Calculate retention probability at a given delay
+ */
+export function calculateRetention(
+  K_star: number,
+  lambda: number,
+  delay_days: number,
+  slip: number = 0.1,
+  guess: number = 0.2
+): number {
+  const K_at_delay = applyForgetting(K_star, lambda, delay_days);
+  // Using slip-guess model
+  return (1 - slip) * K_at_delay + guess * (1 - K_at_delay);
+}

--- a/src/profiles/learnerProfiles.ts
+++ b/src/profiles/learnerProfiles.ts
@@ -1,0 +1,169 @@
+// =============================================================================
+// Learner Profiles
+// Defines the 9 synthetic learner profiles (3 Ability × 3 Calibration)
+// =============================================================================
+
+import {
+  AbilityLevel,
+  CalibrationType,
+  LearnerProfile,
+  LearnerProfileParams,
+  TrueLearnerState,
+  SystemBelief,
+  Item,
+} from '../types';
+
+/**
+ * Profile parameter definitions (Table 2 from pitch)
+ */
+export const PROFILE_PARAMS: Record<string, LearnerProfileParams> = {
+  'Low-Over': {
+    ability: AbilityLevel.LOW,
+    calibration: CalibrationType.OVERCONFIDENT,
+    alpha: 0.10,
+    lambda: 0.15,
+    beta_star: 0.25,
+  },
+  'Low-Under': {
+    ability: AbilityLevel.LOW,
+    calibration: CalibrationType.UNDERCONFIDENT,
+    alpha: 0.10,
+    lambda: 0.15,
+    beta_star: -0.20,
+  },
+  'Low-Well': {
+    ability: AbilityLevel.LOW,
+    calibration: CalibrationType.WELL_CALIBRATED,
+    alpha: 0.10,
+    lambda: 0.15,
+    beta_star: 0.00,
+  },
+  'Med-Over': {
+    ability: AbilityLevel.MEDIUM,
+    calibration: CalibrationType.OVERCONFIDENT,
+    alpha: 0.20,
+    lambda: 0.10,
+    beta_star: 0.20,
+  },
+  'Med-Under': {
+    ability: AbilityLevel.MEDIUM,
+    calibration: CalibrationType.UNDERCONFIDENT,
+    alpha: 0.20,
+    lambda: 0.10,
+    beta_star: -0.15,
+  },
+  'Med-Well': {
+    ability: AbilityLevel.MEDIUM,
+    calibration: CalibrationType.WELL_CALIBRATED,
+    alpha: 0.20,
+    lambda: 0.10,
+    beta_star: 0.00,
+  },
+  'High-Over': {
+    ability: AbilityLevel.HIGH,
+    calibration: CalibrationType.OVERCONFIDENT,
+    alpha: 0.30,
+    lambda: 0.05,
+    beta_star: 0.15,
+  },
+  'High-Under': {
+    ability: AbilityLevel.HIGH,
+    calibration: CalibrationType.UNDERCONFIDENT,
+    alpha: 0.30,
+    lambda: 0.05,
+    beta_star: -0.10,
+  },
+  'High-Well': {
+    ability: AbilityLevel.HIGH,
+    calibration: CalibrationType.WELL_CALIBRATED,
+    alpha: 0.30,
+    lambda: 0.05,
+    beta_star: 0.00,
+  },
+};
+
+/**
+ * Create a learner profile by name
+ */
+export function createLearnerProfile(
+  profileName: string,
+  numItems: number = 100
+): LearnerProfile {
+  const params = PROFILE_PARAMS[profileName];
+  if (!params) {
+    throw new Error(`Unknown profile: ${profileName}`);
+  }
+
+  const trueState: TrueLearnerState = {
+    K_star: 0.3, // Initial global knowledge
+    beta_star: params.beta_star,
+    alpha: params.alpha,
+    alpha_err: params.alpha * 0.5,
+    lambda: params.lambda,
+  };
+
+  const systemBelief: SystemBelief = {
+    K_hat: 0.3,
+    beta_hat: 0, // System starts with no calibration estimate
+    confidence_interval: 0.2,
+    last_updated: new Date(),
+  };
+
+  // Create item pool
+  const items: Item[] = [];
+  for (let i = 0; i < numItems; i++) {
+    const difficulty = (i % 3) * 0.33 + 0.17; // Easy/Medium/Hard
+    items.push(createItem(`item-${i}`, difficulty));
+  }
+
+  return {
+    id: profileName,
+    name: profileName,
+    params,
+    true_state: trueState,
+    system_belief: systemBelief,
+    items,
+    response_history: [],
+    session_count: 0,
+  };
+}
+
+/**
+ * Create an item
+ */
+export function createItem(id: string, difficulty: number): Item {
+  const now = new Date();
+  const tomorrow = new Date(now);
+  tomorrow.setDate(tomorrow.getDate() + 1);
+
+  return {
+    id,
+    difficulty,
+    true_state: {
+      K_star: 0.1, // Start with low knowledge
+      last_review: null,
+    },
+    system_belief: {
+      K_hat: 0.1,
+      beta_hat: 0,
+      next_review: tomorrow,
+      interval_days: 1,
+      ease_factor: 2.5,
+    },
+    review_history: [],
+  };
+}
+
+/**
+ * Get all profile names
+ */
+export function getAllProfileNames(): string[] {
+  return Object.keys(PROFILE_PARAMS);
+}
+
+/**
+ * Create all 9 profiles
+ */
+export function createAllProfiles(numItems: number = 100): LearnerProfile[] {
+  return getAllProfileNames().map(name => createLearnerProfile(name, numItems));
+}

--- a/src/scaffolding/adaptiveScaffolding.ts
+++ b/src/scaffolding/adaptiveScaffolding.ts
@@ -1,0 +1,186 @@
+// =============================================================================
+// Adaptive Scaffolding Module
+// Delivers prompts that modify β* over time (Equation 7)
+// =============================================================================
+
+import {
+  ScaffoldType,
+  CalibrationType,
+  TrueLearnerState,
+  ProcessedResponse,
+} from '../types';
+
+/**
+ * Scaffold prompt templates
+ */
+export const SCAFFOLD_PROMPTS = {
+  [ScaffoldType.REFLECTION]: [
+    "Take a moment to reflect: Was your confidence level accurate for this item?",
+    "Consider: Are you perhaps overestimating your knowledge of this topic?",
+    "Think about what made this item challenging. Does your confidence match the difficulty?",
+    "Pause and ask yourself: Do I truly know this, or am I just familiar with it?",
+  ],
+  [ScaffoldType.ENCOURAGEMENT]: [
+    "You're doing better than you think! Trust your knowledge more.",
+    "Your answer was correct - have more confidence in your abilities!",
+    "Remember: You've studied this material. Give yourself credit for what you know.",
+    "Great job! Your performance suggests you know more than you realize.",
+  ],
+  [ScaffoldType.NONE]: [],
+};
+
+/**
+ * Select appropriate scaffold based on calibration estimate
+ */
+export function selectScaffold(
+  beta_hat: number,
+  _recent_responses: ProcessedResponse[],
+  threshold: number = 0.1
+): ScaffoldType {
+  if (beta_hat > threshold) {
+    return ScaffoldType.REFLECTION;
+  } else if (beta_hat < -threshold) {
+    return ScaffoldType.ENCOURAGEMENT;
+  }
+  return ScaffoldType.NONE;
+}
+
+/**
+ * Check if scaffold should be triggered
+ */
+export function shouldTriggerScaffold(
+  calibration_type: CalibrationType,
+  responses_since_last_scaffold: number,
+  min_interval: number = 5
+): boolean {
+  // Don't scaffold well-calibrated learners
+  if (calibration_type === CalibrationType.WELL_CALIBRATED) {
+    return false;
+  }
+
+  // Don't scaffold too frequently
+  if (responses_since_last_scaffold < min_interval) {
+    return false;
+  }
+
+  return true;
+}
+
+/**
+ * Apply scaffolding effect on true calibration (Equation 7)
+ * β*_{t+1} = β*_t × (1 - δ)
+ */
+export function applyScaffoldingEffect(
+  beta_star: number,
+  delta: number
+): number {
+  // Scaffolding reduces the magnitude of miscalibration
+  return beta_star * (1 - delta);
+}
+
+/**
+ * Get a random prompt for the scaffold type
+ */
+export function getScaffoldPrompt(
+  scaffoldType: ScaffoldType,
+  randomIndex: number = Math.floor(Math.random() * 4)
+): string {
+  const prompts = SCAFFOLD_PROMPTS[scaffoldType];
+  if (prompts.length === 0) return '';
+  return prompts[randomIndex % prompts.length];
+}
+
+/**
+ * Adaptive Scaffolding Manager
+ */
+export class AdaptiveScaffoldingManager {
+  private delta: number;
+  private threshold: number;
+  private minInterval: number;
+  private responsesSinceLastScaffold: number;
+  private scaffoldHistory: Array<{ type: ScaffoldType; timestamp: Date }>;
+
+  constructor(
+    delta: number = 0.03,
+    threshold: number = 0.1,
+    minInterval: number = 5
+  ) {
+    this.delta = delta;
+    this.threshold = threshold;
+    this.minInterval = minInterval;
+    this.responsesSinceLastScaffold = 0;
+    this.scaffoldHistory = [];
+  }
+
+  /**
+   * Process a response and potentially deliver scaffold
+   */
+  processResponse(
+    _response: ProcessedResponse,
+    beta_hat: number,
+    learner_state: TrueLearnerState
+  ): {
+    scaffold: ScaffoldType;
+    prompt: string;
+    updated_beta_star: number;
+  } {
+    this.responsesSinceLastScaffold++;
+
+    // Determine calibration type
+    let calibration_type: CalibrationType;
+    if (beta_hat > this.threshold) {
+      calibration_type = CalibrationType.OVERCONFIDENT;
+    } else if (beta_hat < -this.threshold) {
+      calibration_type = CalibrationType.UNDERCONFIDENT;
+    } else {
+      calibration_type = CalibrationType.WELL_CALIBRATED;
+    }
+
+    // Check if we should trigger scaffold
+    if (!shouldTriggerScaffold(calibration_type, this.responsesSinceLastScaffold, this.minInterval)) {
+      return {
+        scaffold: ScaffoldType.NONE,
+        prompt: '',
+        updated_beta_star: learner_state.beta_star,
+      };
+    }
+
+    // Select and apply scaffold
+    const scaffold = selectScaffold(beta_hat, [], this.threshold);
+
+    if (scaffold !== ScaffoldType.NONE) {
+      this.responsesSinceLastScaffold = 0;
+      this.scaffoldHistory.push({ type: scaffold, timestamp: new Date() });
+
+      const updated_beta_star = applyScaffoldingEffect(learner_state.beta_star, this.delta);
+      const prompt = getScaffoldPrompt(scaffold);
+
+      return {
+        scaffold,
+        prompt,
+        updated_beta_star,
+      };
+    }
+
+    return {
+      scaffold: ScaffoldType.NONE,
+      prompt: '',
+      updated_beta_star: learner_state.beta_star,
+    };
+  }
+
+  /**
+   * Get scaffold history
+   */
+  getHistory(): Array<{ type: ScaffoldType; timestamp: Date }> {
+    return [...this.scaffoldHistory];
+  }
+
+  /**
+   * Reset manager state
+   */
+  reset(): void {
+    this.responsesSinceLastScaffold = 0;
+    this.scaffoldHistory = [];
+  }
+}

--- a/src/scheduler/calibrationAwareScheduler.ts
+++ b/src/scheduler/calibrationAwareScheduler.ts
@@ -1,0 +1,183 @@
+// =============================================================================
+// Calibration-Aware Scheduler (FIXED)
+// Schedules reviews based on K̂, β̂, and dual-process classification
+// =============================================================================
+
+import {
+  Item,
+  ProcessedResponse,
+  SystemBelief,
+  ResponseType,
+} from '../types';
+
+/**
+ * Calculate base interval from knowledge estimate and forgetting rate
+ */
+export function baseInterval(K_hat: number, lambda: number): number {
+  // Higher knowledge = longer interval
+  // Base formula: target K* = 0.7 at next review
+  // 0.7 = K_hat × e^{-λ × t}
+  // t = -ln(0.7/K_hat) / λ
+
+  if (K_hat <= 0.7) return 1; // Review tomorrow if knowledge is low
+  if (lambda === 0) return 30; // Max interval if no forgetting
+
+  const target_retention = 0.7;
+  const interval = -Math.log(target_retention / K_hat) / lambda;
+
+  // Clamp to reasonable range
+  return Math.max(1, Math.min(30, interval));
+}
+
+/**
+ * Adjust interval based on calibration estimate
+ */
+export function calibrationAdjustment(beta_hat: number): number {
+  // Overconfident (β̂ > 0): shorten interval (multiply by < 1)
+  // Underconfident (β̂ < 0): lengthen interval (multiply by > 1)
+  // Well-calibrated (β̂ ≈ 0): no adjustment
+
+  // Adjustment factor: e^{-2β̂}
+  // β̂ = +0.2 → factor ≈ 0.67 (shorter)
+  // β̂ = -0.2 → factor ≈ 1.49 (longer)
+  // β̂ = 0 → factor = 1 (no change)
+
+  return Math.exp(-2 * beta_hat);
+}
+
+/**
+ * Adjust interval based on dual-process classification
+ */
+export function dualProcessAdjustment(
+  responseType: ResponseType,
+  correctness: boolean
+): number {
+  if (!correctness) {
+    return 0.5; // Shorten interval for errors
+  }
+
+  if (responseType === ResponseType.TYPE1_AUTOMATIC) {
+    return 1.2; // Slightly longer for automatized
+  }
+
+  return 1.0; // Standard for deliberate
+}
+
+/**
+ * Compute next review interval for an item
+ */
+export function computeNextReviewInterval(
+  belief: SystemBelief,
+  response: ProcessedResponse,
+  lambda: number,
+  enableCalibration: boolean = true,
+  enableDualProcess: boolean = true
+): number {
+  // Start with base interval
+  let interval = baseInterval(belief.K_hat, lambda);
+
+  // Apply calibration adjustment
+  if (enableCalibration) {
+    interval *= calibrationAdjustment(belief.beta_hat);
+  }
+
+  // Apply dual-process adjustment
+  if (enableDualProcess) {
+    interval *= dualProcessAdjustment(response.response_type, response.correctness);
+  }
+
+  // Clamp to [1, 60] days
+  return Math.max(1, Math.min(60, Math.round(interval)));
+}
+
+/**
+ * Calculate review urgency for an item
+ * Higher urgency = should be reviewed sooner
+ */
+export function calculateUrgency(item: Item, now: Date = new Date()): number {
+  const scheduled = item.system_belief.next_review instanceof Date
+    ? item.system_belief.next_review
+    : new Date(item.system_belief.next_review);
+  const days_until_due = (scheduled.getTime() - now.getTime()) / (24 * 60 * 60 * 1000);
+
+  // Negative days = overdue (high urgency)
+  // Positive days = not yet due (lower urgency)
+  return -days_until_due;
+}
+
+/**
+ * Select next items to review from pool
+ */
+export function selectItemsForReview(
+  items: Item[],
+  count: number,
+  now: Date = new Date()
+): Item[] {
+  // Sort by urgency (most urgent first)
+  const sorted = [...items].sort((a, b) => {
+    return calculateUrgency(b, now) - calculateUrgency(a, now);
+  });
+
+  return sorted.slice(0, count);
+}
+
+/**
+ * CalibrateMe Scheduler (FIXED: removed space in class name)
+ */
+export class CalibrateMeScheduler {
+  private lambda: number;
+  private enableCalibration: boolean;
+  private enableDualProcess: boolean;
+
+  constructor(
+    lambda: number = 0.1,
+    enableCalibration: boolean = true,
+    enableDualProcess: boolean = true
+  ) {
+    this.lambda = lambda;
+    this.enableCalibration = enableCalibration;
+    this.enableDualProcess = enableDualProcess;
+  }
+
+  scheduleNext(
+    item: Item,
+    belief: SystemBelief,
+    response: ProcessedResponse
+  ): { nextReview: Date; interval: number } {
+    const interval = computeNextReviewInterval(
+      belief,
+      response,
+      this.lambda,
+      this.enableCalibration,
+      this.enableDualProcess
+    );
+
+    const nextReview = new Date();
+    nextReview.setDate(nextReview.getDate() + interval);
+    return { nextReview, interval };
+  }
+
+  selectItems(items: Item[], count: number): Item[] {
+    return selectItemsForReview(items, count);
+  }
+
+  /**
+   * Process a response and return scheduling result
+   */
+  processResponse(
+    response: ProcessedResponse,
+    belief: SystemBelief
+  ): { nextReview: Date; interval: number } {
+    const interval = computeNextReviewInterval(
+      belief,
+      response,
+      this.lambda,
+      this.enableCalibration,
+      this.enableDualProcess
+    );
+
+    const nextReview = new Date();
+    nextReview.setDate(nextReview.getDate() + interval);
+    return { nextReview, interval };
+  }
+}

--- a/src/simulation/responseGenerator.ts
+++ b/src/simulation/responseGenerator.ts
@@ -1,0 +1,108 @@
+// =============================================================================
+// Response Generator Module
+// Implements Equations 4, 5, 6 from the project pitch
+// =============================================================================
+
+import { Response, TrueLearnerState, Item, SimulationConfig } from '../types';
+import { SeededRandom, clip } from '../utils/random';
+
+/**
+ * Generate correctness based on slip-guess model (Equation 4)
+ * P(y=1|K*) = (1-s) × K* + g × (1-K*)
+ */
+export function generateCorrectness(
+  K_star: number,
+  slip: number,
+  guess: number,
+  random: SeededRandom
+): boolean {
+  const p_correct = (1 - slip) * K_star + guess * (1 - K_star);
+  return random.randomBoolean(p_correct);
+}
+
+/**
+ * Generate confidence based on true knowledge + miscalibration (Equation 5)
+ * c = clip(K* + β* + ε_c, 0, 1)
+ */
+export function generateConfidence(
+  K_star: number,
+  beta_star: number,
+  noise_std: number,
+  random: SeededRandom
+): number {
+  const epsilon_c = random.randomNormal(0, noise_std);
+  return clip(K_star + beta_star + epsilon_c, 0, 1);
+}
+
+/**
+ * Generate response time based on knowledge level (Equation 6)
+ * τ = τ_base × (1 + γ × (1 - K*)) + ε_τ
+ */
+export function generateResponseTime(
+  K_star: number,
+  tau_base: number,
+  gamma: number,
+  noise_std: number,
+  random: SeededRandom
+): number {
+  const epsilon_tau = random.randomNormal(0, noise_std);
+  const tau = tau_base * (1 + gamma * (1 - K_star)) + epsilon_tau;
+  return Math.max(0.5, tau); // Minimum 0.5 seconds
+}
+
+/**
+ * Generate a complete response for an item
+ */
+export function generateResponse(
+  item: Item,
+  learner_state: TrueLearnerState,
+  config: SimulationConfig,
+  random: SeededRandom
+): Response {
+  const K_star = item.true_state.K_star;
+
+  // Adjust base RT by item difficulty
+  const tau_base_adjusted = config.rt_base * (1 + item.difficulty * 0.5);
+
+  const correctness = generateCorrectness(
+    K_star,
+    config.slip_probability,
+    config.guess_probability,
+    random
+  );
+
+  const confidence = generateConfidence(
+    K_star,
+    learner_state.beta_star,
+    config.confidence_noise_std,
+    random
+  );
+
+  const response_time = generateResponseTime(
+    K_star,
+    tau_base_adjusted,
+    config.rt_gamma,
+    config.rt_noise_std,
+    random
+  );
+
+  return {
+    item_id: item.id,
+    correctness,
+    confidence,
+    response_time,
+    timestamp: new Date(),
+  };
+}
+
+/**
+ * Batch generate responses for multiple items
+ */
+export function generateResponses(
+  items: Item[],
+  learner_state: TrueLearnerState,
+  config: SimulationConfig,
+  random: SeededRandom
+): Response[] {
+  return items.map(item => generateResponse(item, learner_state, config, random));
+}

--- a/src/simulation/simulationEngine.ts
+++ b/src/simulation/simulationEngine.ts
@@ -1,0 +1,387 @@
+// =============================================================================
+// Simulation Engine (FIXED)
+// Orchestrates all modules for running experiments
+// =============================================================================
+
+import {
+  LearnerProfile,
+  ProcessedResponse,
+  SimulationConfig,
+  SimulationResults,
+  SessionData,
+  SchedulerType,
+  ScaffoldType,
+  ResponseType,
+  DEFAULT_SIMULATION_CONFIG,
+  SystemBelief,
+} from '../types';
+import { SeededRandom } from '../utils/random';
+import { mean } from '../utils/statistics';
+import { generateResponse } from './responseGenerator';
+import { calculateCalibrationMetrics } from '../calibration/scoringModule';
+import { updateBelief, updateBetaHat } from '../bkt/beliefUpdateEngine';
+import { applyForgetting, applyLearning, calculateRetention } from '../memory/forgettingModel';
+import { DualProcessClassifier, getDifficultyBin } from '../dualProcess/classifier';
+import { CalibrateMeScheduler, selectItemsForReview } from '../scheduler/calibrationAwareScheduler';
+import { AdaptiveScaffoldingManager } from '../scaffolding/adaptiveScaffolding';
+import { SM2Scheduler } from '../baselines/sm2';
+import { BKTOnlyScheduler } from '../baselines/bktOnly';
+import { DecayBasedScheduler } from '../baselines/decayBased';
+
+/**
+ * Progress callback type for UI updates
+ */
+export type ProgressCallback = (progress: number, message: string) => void;
+
+/**
+ * Deep clone a learner profile to avoid mutation
+ */
+function cloneProfile(profile: LearnerProfile): LearnerProfile {
+  return JSON.parse(JSON.stringify(profile));
+}
+
+/**
+ * Create initial system belief
+ */
+function createInitialBelief(): SystemBelief {
+  return {
+    K_hat: 0.3,
+    beta_hat: 0,
+    confidence_interval: 0.2,
+    last_updated: new Date(),
+  };
+}
+
+/**
+ * Run a complete simulation for a learner profile
+ */
+export function runSimulation(
+  profile: LearnerProfile,
+  config: SimulationConfig = DEFAULT_SIMULATION_CONFIG,
+  onProgress?: ProgressCallback
+): SimulationResults {
+  // Initialize random generator
+  const random = new SeededRandom(config.random_seed ?? Date.now());
+
+  // Clone profile to avoid mutation
+  const learner = cloneProfile(profile);
+
+  // Initialize system belief
+  let systemBelief = createInitialBelief();
+
+  // Initialize modules
+  const dualProcessClassifier = new DualProcessClassifier();
+  const scaffoldingManager = new AdaptiveScaffoldingManager(config.scaffolding_delta);
+
+  // Initialize scheduler based on type
+  let scheduler: SM2Scheduler | BKTOnlyScheduler | DecayBasedScheduler | CalibrateMeScheduler;
+
+  switch (config.scheduler_type) {
+    case SchedulerType.SM2:
+      scheduler = new SM2Scheduler();
+      break;
+    case SchedulerType.BKT_ONLY:
+      scheduler = new BKTOnlyScheduler(learner.params.lambda, config);
+      break;
+    case SchedulerType.DECAY_BASED:
+      scheduler = new DecayBasedScheduler();
+      break;
+    case SchedulerType.CALIBRATEME:
+    default:
+      scheduler = new CalibrateMeScheduler(
+        learner.params.lambda,
+        true,
+        config.enable_dual_process
+      );
+      break;
+  }
+
+  // Tracking variables
+  const eceTrajectory: number[] = [];
+  const brierTrajectory: number[] = [];
+  const KStarTrajectory: number[] = [];
+  const KHatTrajectory: number[] = [];
+  const sessionDataList: SessionData[] = [];
+  const allResponses: ProcessedResponse[] = [];
+
+  let masteryAchievedSession = -1;
+  let masteryCount = 0;
+
+  // Run sessions
+  for (let session = 0; session < config.num_sessions; session++) {
+    // Report progress
+    if (onProgress) {
+      const progress = (session / config.num_sessions) * 100;
+      onProgress(progress, `Running session ${session + 1}/${config.num_sessions}`);
+    }
+
+    // Apply forgetting to all items (simulate time passing)
+    const daysBetweenSessions = session === 0 ? 0 : 1;
+    learner.items = learner.items.map(item => ({
+      ...item,
+      true_state: {
+        ...item.true_state,
+        K_star: applyForgetting(
+          item.true_state.K_star,
+          learner.params.lambda,
+          daysBetweenSessions
+        ),
+      },
+    }));
+
+    // Select items for review
+    const itemsToReview = selectItemsForReview(
+      learner.items,
+      config.items_per_session
+    );
+
+    // Session tracking
+    let correctCount = 0;
+    let type1Count = 0;
+    let type2Count = 0;
+    let scaffoldsDelivered = 0;
+    const sessionResponses: ProcessedResponse[] = [];
+
+    // Process each item
+    for (const item of itemsToReview) {
+      // Generate response based on true state
+      const response = generateResponse(
+        item,
+        learner.true_state,
+        config,
+        random
+      );
+
+      // Process with dual-process classifier
+      const processedResponse = dualProcessClassifier.processResponse(
+        response,
+        getDifficultyBin(item.difficulty)
+      );
+
+      // Update statistics
+      if (processedResponse.correctness) correctCount++;
+      if (processedResponse.response_type === ResponseType.TYPE1_AUTOMATIC) {
+        type1Count++;
+      } else {
+        type2Count++;
+      }
+
+      // Update true knowledge (learning)
+      const newKStar = applyLearning(
+        item.true_state.K_star,
+        response.correctness,
+        learner.true_state.alpha,
+        learner.true_state.alpha_err
+      );
+      item.true_state.K_star = newKStar;
+      item.true_state.last_review = new Date();
+
+      // Update system belief for BKT-based schedulers
+      if (config.scheduler_type === SchedulerType.CALIBRATEME ||
+          config.scheduler_type === SchedulerType.BKT_ONLY) {
+        systemBelief = updateBelief(response, systemBelief, config);
+
+        // Update beta_hat from recent responses
+        const recentResponses = allResponses.slice(-20);
+        if (recentResponses.length > 0) {
+          systemBelief.beta_hat = updateBetaHat(recentResponses, systemBelief.beta_hat);
+        }
+      }
+
+      // Apply scaffolding (CalibrateMe only)
+      if (config.enable_scaffolding && config.scheduler_type === SchedulerType.CALIBRATEME) {
+        const scaffoldResult = scaffoldingManager.processResponse(
+          processedResponse,
+          systemBelief.beta_hat,
+          learner.true_state
+        );
+
+        if (scaffoldResult.scaffold !== ScaffoldType.NONE) {
+          scaffoldsDelivered++;
+          learner.true_state.beta_star = scaffoldResult.updated_beta_star;
+        }
+      }
+
+      // Schedule next review based on scheduler type
+      let scheduleResult: { nextReview: Date; interval: number };
+
+      if (scheduler instanceof CalibrateMeScheduler) {
+        scheduleResult = scheduler.processResponse(processedResponse, systemBelief);
+      } else {
+        scheduleResult = scheduler.processResponse(response);
+      }
+
+      item.system_belief.next_review = scheduleResult.nextReview;
+      item.system_belief.interval_days = scheduleResult.interval;
+
+      // Store response
+      sessionResponses.push(processedResponse);
+      allResponses.push(processedResponse);
+    }
+
+    // Calculate session metrics
+    const metrics = calculateCalibrationMetrics(sessionResponses);
+    eceTrajectory.push(metrics.ece);
+    brierTrajectory.push(metrics.brier_score);
+
+    const meanKStar = mean(learner.items.map(i => i.true_state.K_star));
+    KStarTrajectory.push(meanKStar);
+    KHatTrajectory.push(systemBelief.K_hat);
+
+    // Check mastery (K* > 0.9 sustained for 2 consecutive sessions)
+    if (meanKStar > 0.9) {
+      masteryCount++;
+      if (masteryCount >= 2 && masteryAchievedSession < 0) {
+        masteryAchievedSession = session;
+      }
+    } else {
+      masteryCount = 0;
+    }
+
+    // Store session data
+    sessionDataList.push({
+      session_number: session,
+      items_reviewed: itemsToReview.length,
+      correct_count: correctCount,
+      mean_confidence: mean(sessionResponses.map(r => r.confidence)),
+      mean_rt: mean(sessionResponses.map(r => r.response_time)),
+      type1_count: type1Count,
+      type2_count: type2Count,
+      scaffolds_delivered: scaffoldsDelivered,
+      mean_K_star: meanKStar,
+      mean_K_hat: systemBelief.K_hat,
+      ece: metrics.ece,
+      brier: metrics.brier_score,
+    });
+  }
+
+  // Report completion
+  if (onProgress) {
+    onProgress(100, 'Simulation complete');
+  }
+
+  // Calculate final metrics
+  const finalKStar = mean(learner.items.map(i => i.true_state.K_star));
+  const retention1 = calculateRetention(finalKStar, learner.params.lambda, 1);
+  const retention7 = calculateRetention(finalKStar, learner.params.lambda, 7);
+  const retention30 = calculateRetention(finalKStar, learner.params.lambda, 30);
+
+  return {
+    profile_id: profile.id,
+    scheduler_type: config.scheduler_type,
+    config,
+    retention_1day: retention1,
+    retention_7day: retention7,
+    retention_30day: retention30,
+    time_to_mastery: masteryAchievedSession >= 0 ? masteryAchievedSession : config.num_sessions,
+    review_efficiency: allResponses.length / config.num_items,
+    total_review_time: allResponses.reduce((s, r) => s + r.response_time, 0),
+    ece_trajectory: eceTrajectory,
+    brier_trajectory: brierTrajectory,
+    K_star_trajectory: KStarTrajectory,
+    K_hat_trajectory: KHatTrajectory,
+    session_data: sessionDataList,
+  };
+}
+
+/**
+ * Run simulation asynchronously (for UI responsiveness)
+ */
+export async function runSimulationAsync(
+  profile: LearnerProfile,
+  config: SimulationConfig = DEFAULT_SIMULATION_CONFIG,
+  onProgress?: ProgressCallback
+): Promise<SimulationResults> {
+  return new Promise((resolve) => {
+    // Use setTimeout to allow UI to update
+    setTimeout(() => {
+      const results = runSimulation(profile, config, onProgress);
+      resolve(results);
+    }, 0);
+  });
+}
+
+/**
+ * Run simulations for all profiles and conditions
+ */
+export function runExperiment(
+  profiles: LearnerProfile[],
+  schedulerTypes: SchedulerType[],
+  config: SimulationConfig,
+  replications: number = 1,
+  onProgress?: ProgressCallback
+): Map<string, Map<SchedulerType, SimulationResults[]>> {
+  const results = new Map<string, Map<SchedulerType, SimulationResults[]>>();
+
+  const totalRuns = profiles.length * schedulerTypes.length * replications;
+  let completedRuns = 0;
+
+  for (const profile of profiles) {
+    const profileResults = new Map<SchedulerType, SimulationResults[]>();
+
+    for (const schedulerType of schedulerTypes) {
+      const repResults: SimulationResults[] = [];
+
+      for (let rep = 0; rep < replications; rep++) {
+        const simConfig: SimulationConfig = {
+          ...config,
+          scheduler_type: schedulerType,
+          random_seed: config.random_seed ? config.random_seed + rep : null,
+        };
+
+        const result = runSimulation(profile, simConfig);
+        repResults.push(result);
+
+        completedRuns++;
+        if (onProgress) {
+          const progress = (completedRuns / totalRuns) * 100;
+          onProgress(progress, `${profile.id} - ${schedulerType} - Rep ${rep + 1}`);
+        }
+      }
+
+      profileResults.set(schedulerType, repResults);
+    }
+
+    results.set(profile.id, profileResults);
+  }
+
+  return results;
+}
+
+/**
+ * Run feature-removal tests (ablation study)
+ */
+export function runFeatureRemovalTests(
+  profile: LearnerProfile,
+  baseConfig: SimulationConfig,
+  replications: number = 5
+): Map<string, SimulationResults[]> {
+  const conditions = [
+    { name: 'Full CalibrateMe', config: { ...baseConfig, scheduler_type: SchedulerType.CALIBRATEME, enable_scaffolding: true, enable_dual_process: true } },
+    { name: 'No Dual-Process', config: { ...baseConfig, scheduler_type: SchedulerType.CALIBRATEME, enable_scaffolding: true, enable_dual_process: false } },
+    { name: 'No Scaffolding', config: { ...baseConfig, scheduler_type: SchedulerType.CALIBRATEME, enable_scaffolding: false, enable_dual_process: true } },
+    { name: 'Calibration Only', config: { ...baseConfig, scheduler_type: SchedulerType.CALIBRATEME, enable_scaffolding: false, enable_dual_process: false } },
+    { name: 'SM-2 Baseline', config: { ...baseConfig, scheduler_type: SchedulerType.SM2 } },
+    { name: 'BKT-Only', config: { ...baseConfig, scheduler_type: SchedulerType.BKT_ONLY } },
+  ];
+
+  const results = new Map<string, SimulationResults[]>();
+
+  for (const condition of conditions) {
+    const conditionResults: SimulationResults[] = [];
+
+    for (let rep = 0; rep < replications; rep++) {
+      const config: SimulationConfig = {
+        ...condition.config,
+        random_seed: baseConfig.random_seed ? baseConfig.random_seed + rep : rep,
+      };
+
+      const result = runSimulation(profile, config);
+      conditionResults.push(result);
+    }
+
+    results.set(condition.name, conditionResults);
+  }
+
+  return results;
+}

--- a/src/store/simulationStore.ts
+++ b/src/store/simulationStore.ts
@@ -1,0 +1,146 @@
+// =============================================================================
+// Zustand Store for Simulation State (FIXED)
+// =============================================================================
+
+import { create } from 'zustand';
+import {
+  LearnerProfile,
+  SimulationConfig,
+  SimulationResults,
+  SchedulerType,
+  DEFAULT_SIMULATION_CONFIG,
+} from '../types';
+import { createLearnerProfile } from '../profiles/learnerProfiles';
+import { runSimulationAsync } from '../simulation/simulationEngine';
+
+interface SimulationStore {
+  // State
+  selectedProfile: string;
+  config: SimulationConfig;
+  profile: LearnerProfile | null;
+  results: SimulationResults | null;
+  comparisonResults: Map<SchedulerType, SimulationResults> | null;
+  isRunning: boolean;
+  progress: number;
+  progressMessage: string;
+  error: string | null;
+
+  // Actions
+  setSelectedProfile: (profileName: string) => void;
+  setSchedulerType: (type: SchedulerType) => void;
+  setConfig: (config: Partial<SimulationConfig>) => void;
+  runSimulation: () => Promise<void>;
+  runComparison: () => Promise<void>;
+  reset: () => void;
+}
+
+export const useSimulationStore = create<SimulationStore>((set, get) => ({
+  // Initial state
+  selectedProfile: 'Med-Over',
+  config: DEFAULT_SIMULATION_CONFIG,
+  profile: null,
+  results: null,
+  comparisonResults: null,
+  isRunning: false,
+  progress: 0,
+  progressMessage: '',
+  error: null,
+
+  // Actions
+  setSelectedProfile: (profileName: string) => {
+    set({ selectedProfile: profileName, results: null, comparisonResults: null });
+  },
+
+  setSchedulerType: (type: SchedulerType) => {
+    set(state => ({
+      config: { ...state.config, scheduler_type: type },
+      results: null,
+    }));
+  },
+
+  setConfig: (newConfig: Partial<SimulationConfig>) => {
+    set(state => ({
+      config: { ...state.config, ...newConfig },
+      results: null,
+    }));
+  },
+
+  runSimulation: async () => {
+    const { selectedProfile, config } = get();
+
+    set({ isRunning: true, error: null, progress: 0, progressMessage: 'Initializing...' });
+
+    try {
+      // Create profile
+      const profile = createLearnerProfile(selectedProfile, config.num_items);
+
+      // Run simulation with progress callback
+      const results = await runSimulationAsync(profile, config, (progress, message) => {
+        set({ progress, progressMessage: message });
+      });
+
+      set({ profile, results, isRunning: false, progress: 100, progressMessage: 'Complete' });
+    } catch (err) {
+      set({
+        error: err instanceof Error ? err.message : 'Simulation failed',
+        isRunning: false,
+        progress: 0,
+        progressMessage: '',
+      });
+    }
+  },
+
+  runComparison: async () => {
+    const { selectedProfile, config } = get();
+
+    set({ isRunning: true, error: null, progress: 0, progressMessage: 'Running comparison...' });
+
+    try {
+      const profile = createLearnerProfile(selectedProfile, config.num_items);
+      const schedulerTypes = [
+        SchedulerType.CALIBRATEME,
+        SchedulerType.SM2,
+        SchedulerType.BKT_ONLY,
+        SchedulerType.DECAY_BASED,
+      ];
+
+      const comparisonResults = new Map<SchedulerType, SimulationResults>();
+
+      for (let i = 0; i < schedulerTypes.length; i++) {
+        const schedulerType = schedulerTypes[i];
+        set({
+          progress: (i / schedulerTypes.length) * 100,
+          progressMessage: `Running ${schedulerType}...`
+        });
+
+        const simConfig = { ...config, scheduler_type: schedulerType };
+        const result = await runSimulationAsync(profile, simConfig);
+        comparisonResults.set(schedulerType, result);
+      }
+
+      set({
+        profile,
+        comparisonResults,
+        isRunning: false,
+        progress: 100,
+        progressMessage: 'Comparison complete'
+      });
+    } catch (err) {
+      set({
+        error: err instanceof Error ? err.message : 'Comparison failed',
+        isRunning: false,
+      });
+    }
+  },
+
+  reset: () => {
+    set({
+      profile: null,
+      results: null,
+      comparisonResults: null,
+      error: null,
+      progress: 0,
+      progressMessage: '',
+    });
+  },
+}));

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,297 @@
+// =============================================================================
+// CalibrateMe Type Definitions
+// =============================================================================
+
+// -----------------------------------------------------------------------------
+// Enums
+// -----------------------------------------------------------------------------
+
+export enum AbilityLevel {
+  LOW = 'LOW',
+  MEDIUM = 'MEDIUM',
+  HIGH = 'HIGH',
+}
+
+export enum CalibrationType {
+  OVERCONFIDENT = 'OVERCONFIDENT',
+  UNDERCONFIDENT = 'UNDERCONFIDENT',
+  WELL_CALIBRATED = 'WELL_CALIBRATED',
+}
+
+export enum ResponseType {
+  TYPE1_AUTOMATIC = 'TYPE1_AUTOMATIC',
+  TYPE2_DELIBERATE = 'TYPE2_DELIBERATE',
+}
+
+export enum ScaffoldType {
+  REFLECTION = 'REFLECTION',           // For overconfident learners
+  ENCOURAGEMENT = 'ENCOURAGEMENT',     // For underconfident learners
+  NONE = 'NONE',
+}
+
+export enum SchedulerType {
+  CALIBRATEME = 'CALIBRATEME',
+  SM2 = 'SM2',
+  BKT_ONLY = 'BKT_ONLY',
+  DECAY_BASED = 'DECAY_BASED',
+}
+
+// -----------------------------------------------------------------------------
+// Core Interfaces
+// -----------------------------------------------------------------------------
+
+/**
+ * True (hidden) state of the learner - generates observable behavior
+ * The system cannot directly access this; it must infer from responses
+ */
+export interface TrueLearnerState {
+  K_star: number;           // True knowledge level [0, 1]
+  beta_star: number;        // True calibration bias [-0.3, +0.3]
+  alpha: number;            // Learning rate on correct responses [0.1, 0.3]
+  alpha_err: number;        // Learning rate on errors (typically 0.5 * alpha)
+  lambda: number;           // Forgetting rate [0.05, 0.15]
+}
+
+/**
+ * System's belief about the learner - updated via BKT from observations
+ */
+export interface SystemBelief {
+  K_hat: number;            // Estimated knowledge level [0, 1]
+  beta_hat: number;         // Estimated calibration bias
+  confidence_interval: number; // Uncertainty in estimate
+  last_updated: Date;
+}
+
+/**
+ * Item being learned (e.g., a vocabulary word, flashcard)
+ */
+export interface Item {
+  id: string;
+  difficulty: number;       // Item difficulty [0, 1]
+  true_state: ItemTrueState;
+  system_belief: ItemSystemBelief;
+  review_history: ReviewRecord[];
+}
+
+export interface ItemTrueState {
+  K_star: number;           // True knowledge for this specific item
+  last_review: Date | null;
+}
+
+export interface ItemSystemBelief {
+  K_hat: number;
+  beta_hat: number;
+  next_review: Date;
+  interval_days: number;
+  ease_factor: number;      // For SM-2 compatibility
+}
+
+/**
+ * A single response from the learner
+ */
+export interface Response {
+  item_id: string;
+  correctness: boolean;     // y: correct (true) or incorrect (false)
+  confidence: number;       // c: reported confidence [0, 1]
+  response_time: number;    // τ: response time in seconds
+  timestamp: Date;
+}
+
+/**
+ * Processed response with additional computed fields
+ */
+export interface ProcessedResponse extends Response {
+  response_type: ResponseType;
+  normalized_rt: number;
+  dual_process_score: number;
+  brier_score: number;
+}
+
+/**
+ * Record of a single review session
+ */
+export interface ReviewRecord {
+  response: ProcessedResponse;
+  K_star_before: number;
+  K_star_after: number;
+  K_hat_before: number;
+  K_hat_after: number;
+  interval_assigned: number;
+  scaffold_delivered: ScaffoldType;
+}
+
+// -----------------------------------------------------------------------------
+// Learner Profile
+// -----------------------------------------------------------------------------
+
+export interface LearnerProfileParams {
+  ability: AbilityLevel;
+  calibration: CalibrationType;
+  alpha: number;
+  lambda: number;
+  beta_star: number;
+}
+
+export interface LearnerProfile {
+  id: string;
+  name: string;
+  params: LearnerProfileParams;
+  true_state: TrueLearnerState;
+  system_belief: SystemBelief;
+  items: Item[];
+  response_history: ProcessedResponse[];
+  session_count: number;
+}
+
+// -----------------------------------------------------------------------------
+// Calibration Metrics
+// -----------------------------------------------------------------------------
+
+export interface CalibrationMetrics {
+  brier_score: number;      // Mean squared error of confidence
+  ece: number;              // Expected Calibration Error
+  mce: number;              // Maximum Calibration Error
+  calibration_direction: CalibrationType;
+  bin_data: CalibrationBin[];
+}
+
+export interface CalibrationBin {
+  bin_start: number;
+  bin_end: number;
+  mean_confidence: number;
+  mean_accuracy: number;
+  count: number;
+  calibration_gap: number;  // accuracy - confidence
+}
+
+// -----------------------------------------------------------------------------
+// Simulation Configuration
+// -----------------------------------------------------------------------------
+
+export interface SimulationConfig {
+  num_items: number;
+  num_sessions: number;
+  items_per_session: number;
+  scheduler_type: SchedulerType;
+  enable_scaffolding: boolean;
+  enable_dual_process: boolean;
+  random_seed: number | null;
+
+  // Model parameters
+  slip_probability: number;       // s = 0.1
+  guess_probability: number;      // g = 0.2
+  confidence_noise_std: number;   // σ_c = 0.1
+  rt_noise_std: number;           // σ_τ = 0.5
+  rt_base: number;                // Base response time in seconds
+  rt_gamma: number;               // Knowledge-RT relationship strength
+  scaffolding_delta: number;      // δ ∈ [0.02, 0.05]
+}
+
+export const DEFAULT_SIMULATION_CONFIG: SimulationConfig = {
+  num_items: 100,
+  num_sessions: 30,
+  items_per_session: 20,
+  scheduler_type: SchedulerType.CALIBRATEME,
+  enable_scaffolding: true,
+  enable_dual_process: true,
+  random_seed: null,
+  slip_probability: 0.1,
+  guess_probability: 0.2,
+  confidence_noise_std: 0.1,
+  rt_noise_std: 0.5,
+  rt_base: 3.0,
+  rt_gamma: 2.0,
+  scaffolding_delta: 0.03,
+};
+
+// -----------------------------------------------------------------------------
+// Simulation Results
+// -----------------------------------------------------------------------------
+
+export interface SimulationResults {
+  profile_id: string;
+  scheduler_type: SchedulerType;
+  config: SimulationConfig;
+
+  // Primary metrics
+  retention_1day: number;
+  retention_7day: number;
+  retention_30day: number;
+  time_to_mastery: number;      // Sessions until K* > 0.9 sustained
+  review_efficiency: number;    // Reviews per mastered item
+  total_review_time: number;    // Cost proxy
+
+  // Calibration trajectory
+  ece_trajectory: number[];
+  brier_trajectory: number[];
+
+  // Knowledge trajectory
+  K_star_trajectory: number[];
+  K_hat_trajectory: number[];
+
+  // Per-session data
+  session_data: SessionData[];
+}
+
+export interface SessionData {
+  session_number: number;
+  items_reviewed: number;
+  correct_count: number;
+  mean_confidence: number;
+  mean_rt: number;
+  type1_count: number;
+  type2_count: number;
+  scaffolds_delivered: number;
+  mean_K_star: number;
+  mean_K_hat: number;
+  ece: number;
+  brier: number;
+}
+
+// -----------------------------------------------------------------------------
+// Experiment Configuration
+// -----------------------------------------------------------------------------
+
+export interface ExperimentConfig {
+  profiles: LearnerProfile[];
+  conditions: SchedulerType[];
+  simulation_config: SimulationConfig;
+  num_replications: number;
+}
+
+export interface ExperimentResults {
+  config: ExperimentConfig;
+  results: Map<string, Map<SchedulerType, SimulationResults[]>>;
+  summary: ExperimentSummary;
+}
+
+export interface ExperimentSummary {
+  by_profile: Map<string, ProfileSummary>;
+  by_scheduler: Map<SchedulerType, SchedulerSummary>;
+  hypothesis_tests: HypothesisTestResults;
+}
+
+export interface ProfileSummary {
+  profile_id: string;
+  mean_retention_1day: Map<SchedulerType, number>;
+  mean_retention_7day: Map<SchedulerType, number>;
+  mean_retention_30day: Map<SchedulerType, number>;
+  mean_time_to_mastery: Map<SchedulerType, number>;
+  improvement_vs_sm2: number;
+}
+
+export interface SchedulerSummary {
+  scheduler_type: SchedulerType;
+  mean_retention_1day: number;
+  mean_retention_7day: number;
+  mean_retention_30day: number;
+  mean_time_to_mastery: number;
+}
+
+export interface HypothesisTestResults {
+  h1_overconfident_largest_improvement: boolean;
+  h2_underconfident_moderate_improvement: boolean;
+  h3_wellcalibrated_minimal_difference: boolean;
+  effect_sizes: Map<string, number>;
+  p_values: Map<string, number>;
+}

--- a/src/utils/export.ts
+++ b/src/utils/export.ts
@@ -1,0 +1,80 @@
+// =============================================================================
+// Export Utilities
+// =============================================================================
+
+import { SimulationResults } from '../types';
+
+/**
+ * Export simulation results to CSV format
+ */
+export function exportToCSV(results: SimulationResults): string {
+  const headers = [
+    'session',
+    'items_reviewed',
+    'correct_count',
+    'accuracy',
+    'mean_confidence',
+    'mean_rt',
+    'type1_count',
+    'type2_count',
+    'scaffolds',
+    'mean_K_star',
+    'mean_K_hat',
+    'ece',
+    'brier',
+  ];
+
+  const rows = results.session_data.map(s => [
+    s.session_number + 1,
+    s.items_reviewed,
+    s.correct_count,
+    (s.correct_count / s.items_reviewed).toFixed(4),
+    s.mean_confidence.toFixed(4),
+    s.mean_rt.toFixed(2),
+    s.type1_count,
+    s.type2_count,
+    s.scaffolds_delivered,
+    s.mean_K_star.toFixed(4),
+    s.mean_K_hat.toFixed(4),
+    s.ece.toFixed(4),
+    s.brier.toFixed(4),
+  ]);
+
+  return [headers.join(','), ...rows.map(r => r.join(','))].join('\n');
+}
+
+/**
+ * Export simulation results to JSON format
+ */
+export function exportToJSON(results: SimulationResults): string {
+  return JSON.stringify(results, null, 2);
+}
+
+/**
+ * Download file in browser
+ */
+export function downloadFile(content: string, filename: string, type: string): void {
+  const blob = new Blob([content], { type });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}
+
+/**
+ * Export results as CSV download
+ */
+export function downloadCSV(results: SimulationResults, filename: string = 'results.csv'): void {
+  downloadFile(exportToCSV(results), filename, 'text/csv');
+}
+
+/**
+ * Export results as JSON download
+ */
+export function downloadJSON(results: SimulationResults, filename: string = 'results.json'): void {
+  downloadFile(exportToJSON(results), filename, 'application/json');
+}

--- a/src/utils/random.ts
+++ b/src/utils/random.ts
@@ -1,0 +1,84 @@
+// =============================================================================
+// Random Number Generation Utilities
+// =============================================================================
+
+/**
+ * Seeded random number generator for reproducibility
+ * Uses a simple linear congruential generator
+ */
+export class SeededRandom {
+  private seed: number;
+
+  constructor(seed: number = Date.now()) {
+    this.seed = seed;
+  }
+
+  /**
+   * Generate a random number in [0, 1)
+   */
+  random(): number {
+    // LCG parameters (same as glibc)
+    this.seed = (this.seed * 1103515245 + 12345) & 0x7fffffff;
+    return this.seed / 0x7fffffff;
+  }
+
+  /**
+   * Generate a random number in [min, max)
+   */
+  randomRange(min: number, max: number): number {
+    return min + this.random() * (max - min);
+  }
+
+  /**
+   * Generate a random integer in [min, max]
+   */
+  randomInt(min: number, max: number): number {
+    return Math.floor(this.randomRange(min, max + 1));
+  }
+
+  /**
+   * Generate a random number from standard normal distribution
+   * Using Box-Muller transform
+   */
+  randomNormal(mean: number = 0, std: number = 1): number {
+    const u1 = this.random();
+    const u2 = this.random();
+    const z = Math.sqrt(-2 * Math.log(u1)) * Math.cos(2 * Math.PI * u2);
+    return mean + z * std;
+  }
+
+  /**
+   * Generate a random boolean with given probability
+   */
+  randomBoolean(probability: number = 0.5): boolean {
+    return this.random() < probability;
+  }
+
+  /**
+   * Shuffle an array in place
+   */
+  shuffle<T>(array: T[]): T[] {
+    for (let i = array.length - 1; i > 0; i--) {
+      const j = this.randomInt(0, i);
+      [array[i], array[j]] = [array[j], array[i]];
+    }
+    return array;
+  }
+
+  /**
+   * Reset the seed
+   */
+  setSeed(seed: number): void {
+    this.seed = seed;
+  }
+}
+
+// Global random instance (can be seeded for reproducibility)
+export const globalRandom = new SeededRandom();
+
+/**
+ * Clip a value to [min, max]
+ */
+export function clip(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}

--- a/src/utils/statistics.ts
+++ b/src/utils/statistics.ts
@@ -1,0 +1,93 @@
+// =============================================================================
+// Statistical Utilities
+// =============================================================================
+
+/**
+ * Calculate mean of an array
+ */
+export function mean(values: number[]): number {
+  if (values.length === 0) return 0;
+  return values.reduce((sum, v) => sum + v, 0) / values.length;
+}
+
+/**
+ * Calculate variance of an array
+ */
+export function variance(values: number[]): number {
+  if (values.length < 2) return 0;
+  const m = mean(values);
+  return values.reduce((sum, v) => sum + (v - m) ** 2, 0) / (values.length - 1);
+}
+
+/**
+ * Calculate standard deviation of an array
+ */
+export function std(values: number[]): number {
+  return Math.sqrt(variance(values));
+}
+
+/**
+ * Online mean and variance calculator (Welford's algorithm)
+ */
+export class OnlineStatistics {
+  private n: number = 0;
+  private mean_: number = 0;
+  private M2: number = 0;
+
+  update(value: number): void {
+    this.n++;
+    const delta = value - this.mean_;
+    this.mean_ += delta / this.n;
+    const delta2 = value - this.mean_;
+    this.M2 += delta * delta2;
+  }
+
+  get count(): number {
+    return this.n;
+  }
+
+  get mean(): number {
+    return this.mean_;
+  }
+
+  get variance(): number {
+    return this.n < 2 ? 0 : this.M2 / (this.n - 1);
+  }
+
+  get std(): number {
+    return Math.sqrt(this.variance);
+  }
+
+  reset(): void {
+    this.n = 0;
+    this.mean_ = 0;
+    this.M2 = 0;
+  }
+}
+
+/**
+ * Calculate z-score
+ */
+export function zScore(value: number, mean: number, std: number): number {
+  if (std === 0) return 0;
+  return (value - mean) / std;
+}
+
+/**
+ * Calculate Cohen's d effect size
+ */
+export function cohensD(group1: number[], group2: number[]): number {
+  const m1 = mean(group1);
+  const m2 = mean(group2);
+  const s1 = std(group1);
+  const s2 = std(group2);
+  const n1 = group1.length;
+  const n2 = group2.length;
+
+  // Pooled standard deviation
+  const pooledStd = Math.sqrt(
+    ((n1 - 1) * s1 ** 2 + (n2 - 1) * s2 ** 2) / (n1 + n2 - 2)
+  );
+
+  return pooledStd === 0 ? 0 : (m1 - m2) / pooledStd;
+}

--- a/tests/beliefUpdateEngine.test.ts
+++ b/tests/beliefUpdateEngine.test.ts
@@ -1,0 +1,101 @@
+import {
+  likelihoodCorrectness,
+  likelihoodConfidence,
+  likelihoodRT,
+  updateBelief,
+  updateBetaHat,
+} from '../src/bkt/beliefUpdateEngine';
+import { Response, SystemBelief, DEFAULT_SIMULATION_CONFIG } from '../src/types';
+
+describe('Belief Update Engine', () => {
+  describe('likelihoodCorrectness', () => {
+    it('should return higher likelihood for correct when K is high', () => {
+      const lCorrect = likelihoodCorrectness(true, 0.9, 0.1, 0.2);
+      const lIncorrect = likelihoodCorrectness(false, 0.9, 0.1, 0.2);
+      expect(lCorrect).toBeGreaterThan(lIncorrect);
+    });
+
+    it('should return higher likelihood for incorrect when K is low', () => {
+      const lCorrect = likelihoodCorrectness(true, 0.1, 0.1, 0.2);
+      const lIncorrect = likelihoodCorrectness(false, 0.1, 0.1, 0.2);
+      expect(lIncorrect).toBeGreaterThan(lCorrect);
+    });
+  });
+
+  describe('likelihoodConfidence', () => {
+    it('should be highest when confidence matches expected', () => {
+      const K_hat = 0.5;
+      const beta_hat = 0.1;
+      const expected_c = K_hat + beta_hat; // 0.6
+
+      const L_match = likelihoodConfidence(expected_c, K_hat, beta_hat, 0.1);
+      const L_off = likelihoodConfidence(0.3, K_hat, beta_hat, 0.1);
+
+      expect(L_match).toBeGreaterThan(L_off);
+    });
+  });
+
+  describe('likelihoodRT', () => {
+    it('should be highest when RT matches expected', () => {
+      const K_hat = 0.5;
+      const tau_base = 3;
+      const gamma = 2;
+      const expected_tau = tau_base * (1 + gamma * (1 - K_hat)); // 6.0
+
+      const L_match = likelihoodRT(expected_tau, K_hat, tau_base, gamma, 0.5);
+      const L_off = likelihoodRT(2, K_hat, tau_base, gamma, 0.5);
+
+      expect(L_match).toBeGreaterThan(L_off);
+    });
+  });
+
+  describe('updateBelief', () => {
+    const initialBelief: SystemBelief = {
+      K_hat: 0.5,
+      beta_hat: 0,
+      confidence_interval: 0.2,
+      last_updated: new Date(),
+    };
+
+    it('should increase K_hat after correct response with high confidence', () => {
+      const response: Response = {
+        item_id: 'test',
+        correctness: true,
+        confidence: 0.8,
+        response_time: 2,
+        timestamp: new Date(),
+      };
+
+      const updated = updateBelief(response, initialBelief, DEFAULT_SIMULATION_CONFIG);
+      expect(updated.K_hat).toBeGreaterThan(initialBelief.K_hat);
+    });
+
+    it('should decrease K_hat after incorrect response with low confidence', () => {
+      const response: Response = {
+        item_id: 'test',
+        correctness: false,
+        confidence: 0.2,
+        response_time: 5,
+        timestamp: new Date(),
+      };
+
+      const updated = updateBelief(response, initialBelief, DEFAULT_SIMULATION_CONFIG);
+      expect(updated.K_hat).toBeLessThan(initialBelief.K_hat);
+    });
+  });
+
+  describe('updateBetaHat', () => {
+    it('should detect overconfidence from responses', () => {
+      const responses: Response[] = Array(20).fill(null).map((_, i) => ({
+        item_id: `${i}`,
+        correctness: i < 10, // 50% accuracy
+        confidence: 0.8,     // 80% confidence
+        response_time: 2,
+        timestamp: new Date(),
+      }));
+
+      const beta = updateBetaHat(responses, 0);
+      expect(beta).toBeGreaterThan(0); // Should detect overconfidence
+    });
+  });
+});

--- a/tests/dualProcess.test.ts
+++ b/tests/dualProcess.test.ts
@@ -1,0 +1,83 @@
+import { DualProcessClassifier, getDifficultyBin } from '../src/dualProcess/classifier';
+import { ResponseType } from '../src/types';
+
+describe('Dual Process Classifier', () => {
+  describe('getDifficultyBin', () => {
+    it('should classify easy items', () => {
+      expect(getDifficultyBin(0.1)).toBe('easy');
+    });
+
+    it('should classify medium items', () => {
+      expect(getDifficultyBin(0.5)).toBe('medium');
+    });
+
+    it('should classify hard items', () => {
+      expect(getDifficultyBin(0.8)).toBe('hard');
+    });
+  });
+
+  describe('DualProcessClassifier', () => {
+    let classifier: DualProcessClassifier;
+
+    beforeEach(() => {
+      classifier = new DualProcessClassifier();
+    });
+
+    it('should classify as Type 2 by default with few responses', () => {
+      const result = classifier.processResponse(
+        {
+          item_id: 'test',
+          correctness: true,
+          confidence: 0.9,
+          response_time: 2,
+          timestamp: new Date(),
+        },
+        'medium'
+      );
+      // With < 5 responses, normalizeRT returns 0
+      expect(result.response_type).toBe(ResponseType.TYPE2_DELIBERATE);
+    });
+
+    it('should classify errors as Type 2', () => {
+      // Add enough responses for normalization
+      for (let i = 0; i < 10; i++) {
+        classifier.processResponse(
+          {
+            item_id: `item-${i}`,
+            correctness: true,
+            confidence: 0.5,
+            response_time: 3,
+            timestamp: new Date(),
+          },
+          'medium'
+        );
+      }
+
+      const result = classifier.processResponse(
+        {
+          item_id: 'test',
+          correctness: false,
+          confidence: 0.3,
+          response_time: 5,
+          timestamp: new Date(),
+        },
+        'medium'
+      );
+      expect(result.response_type).toBe(ResponseType.TYPE2_DELIBERATE);
+    });
+
+    it('should compute Brier score correctly', () => {
+      const result = classifier.processResponse(
+        {
+          item_id: 'test',
+          correctness: true,
+          confidence: 0.8,
+          response_time: 2,
+          timestamp: new Date(),
+        },
+        'medium'
+      );
+      expect(result.brier_score).toBeCloseTo(0.04, 2); // (0.8 - 1)^2 = 0.04
+    });
+  });
+});

--- a/tests/forgettingModel.test.ts
+++ b/tests/forgettingModel.test.ts
@@ -1,0 +1,92 @@
+import {
+  applyForgetting,
+  optimalReviewTime,
+  calculateRetention,
+  applyLearning,
+} from '../src/memory/forgettingModel';
+
+describe('Forgetting Model', () => {
+  describe('applyForgetting', () => {
+    it('should return same value for 0 time elapsed', () => {
+      expect(applyForgetting(0.8, 0.1, 0)).toBe(0.8);
+    });
+
+    it('should decay knowledge over time', () => {
+      const K_initial = 0.9;
+      const K_after = applyForgetting(K_initial, 0.1, 7);
+      expect(K_after).toBeLessThan(K_initial);
+    });
+
+    it('should decay faster with higher lambda', () => {
+      const K_initial = 0.9;
+      const K_slow = applyForgetting(K_initial, 0.05, 7);
+      const K_fast = applyForgetting(K_initial, 0.15, 7);
+      expect(K_fast).toBeLessThan(K_slow);
+    });
+
+    it('should follow exponential decay formula', () => {
+      const K_initial = 1.0;
+      const lambda = 0.1;
+      const t = 10;
+      const expected = Math.exp(-lambda * t);
+      expect(applyForgetting(K_initial, lambda, t)).toBeCloseTo(expected, 5);
+    });
+  });
+
+  describe('optimalReviewTime', () => {
+    it('should return 0 if knowledge is already below threshold', () => {
+      expect(optimalReviewTime(0.5, 0.1, 0.7)).toBe(0);
+    });
+
+    it('should return correct time for knowledge to decay to threshold', () => {
+      // K* = 1.0, threshold = 0.5, lambda = 0.1
+      // 0.5 = 1.0 * e^(-0.1 * t)
+      // t = -ln(0.5) / 0.1 ≈ 6.93
+      const t = optimalReviewTime(1.0, 0.1, 0.5);
+      expect(t).toBeCloseTo(6.93, 1);
+    });
+  });
+
+  describe('calculateRetention', () => {
+    it('should return high retention for high knowledge', () => {
+      const retention = calculateRetention(0.9, 0.1, 1);
+      expect(retention).toBeGreaterThan(0.7);
+    });
+
+    it('should return lower retention over longer delays', () => {
+      const K_star = 0.8;
+      const lambda = 0.1;
+      const ret1 = calculateRetention(K_star, lambda, 1);
+      const ret7 = calculateRetention(K_star, lambda, 7);
+      const ret30 = calculateRetention(K_star, lambda, 30);
+
+      expect(ret1).toBeGreaterThan(ret7);
+      expect(ret7).toBeGreaterThan(ret30);
+    });
+  });
+
+  describe('applyLearning', () => {
+    it('should increase knowledge on correct response', () => {
+      const K_before = 0.5;
+      const K_after = applyLearning(K_before, true, 0.2, 0.1);
+      expect(K_after).toBeGreaterThan(K_before);
+    });
+
+    it('should increase knowledge on incorrect response (less)', () => {
+      const K_before = 0.5;
+      const K_correct = applyLearning(K_before, true, 0.2, 0.1);
+      const K_error = applyLearning(K_before, false, 0.2, 0.1);
+      expect(K_error).toBeGreaterThan(K_before);
+      expect(K_error).toBeLessThan(K_correct);
+    });
+
+    it('should approach 1.0 asymptotically', () => {
+      let K = 0.5;
+      for (let i = 0; i < 100; i++) {
+        K = applyLearning(K, true, 0.2, 0.1);
+      }
+      expect(K).toBeGreaterThan(0.99);
+      expect(K).toBeLessThanOrEqual(1.0);
+    });
+  });
+});

--- a/tests/responseGenerator.test.ts
+++ b/tests/responseGenerator.test.ts
@@ -1,0 +1,75 @@
+import { generateCorrectness, generateConfidence, generateResponseTime } from '../src/simulation/responseGenerator';
+import { SeededRandom } from '../src/utils/random';
+
+describe('Response Generator', () => {
+  const random = new SeededRandom(12345);
+
+  beforeEach(() => {
+    random.setSeed(12345);
+  });
+
+  describe('generateCorrectness', () => {
+    it('should generate correct responses more often with high knowledge', () => {
+      let correctCount = 0;
+      for (let i = 0; i < 1000; i++) {
+        if (generateCorrectness(0.9, 0.1, 0.2, random)) correctCount++;
+      }
+      // P(correct|K*=0.9) = 0.9 * 0.9 + 0.2 * 0.1 = 0.83
+      expect(correctCount / 1000).toBeCloseTo(0.83, 1);
+    });
+
+    it('should generate incorrect responses more often with low knowledge', () => {
+      let correctCount = 0;
+      for (let i = 0; i < 1000; i++) {
+        if (generateCorrectness(0.1, 0.1, 0.2, random)) correctCount++;
+      }
+      // P(correct|K*=0.1) = 0.9 * 0.1 + 0.2 * 0.9 = 0.27
+      expect(correctCount / 1000).toBeCloseTo(0.27, 1);
+    });
+  });
+
+  describe('generateConfidence', () => {
+    it('should generate higher confidence with overconfidence bias', () => {
+      const confidences: number[] = [];
+      for (let i = 0; i < 100; i++) {
+        confidences.push(generateConfidence(0.5, 0.2, 0.1, random));
+      }
+      const mean = confidences.reduce((a, b) => a + b, 0) / confidences.length;
+      expect(mean).toBeGreaterThan(0.6); // K* + β* = 0.7
+    });
+
+    it('should generate lower confidence with underconfidence bias', () => {
+      const confidences: number[] = [];
+      for (let i = 0; i < 100; i++) {
+        confidences.push(generateConfidence(0.5, -0.2, 0.1, random));
+      }
+      const mean = confidences.reduce((a, b) => a + b, 0) / confidences.length;
+      expect(mean).toBeLessThan(0.4); // K* + β* = 0.3
+    });
+
+    it('should clip confidence to [0, 1]', () => {
+      for (let i = 0; i < 100; i++) {
+        const c = generateConfidence(0.9, 0.3, 0.2, random);
+        expect(c).toBeGreaterThanOrEqual(0);
+        expect(c).toBeLessThanOrEqual(1);
+      }
+    });
+  });
+
+  describe('generateResponseTime', () => {
+    it('should generate faster responses with high knowledge', () => {
+      const highK: number[] = [];
+      const lowK: number[] = [];
+
+      for (let i = 0; i < 100; i++) {
+        highK.push(generateResponseTime(0.9, 3, 2, 0.5, random));
+        lowK.push(generateResponseTime(0.1, 3, 2, 0.5, random));
+      }
+
+      const highMean = highK.reduce((a, b) => a + b, 0) / highK.length;
+      const lowMean = lowK.reduce((a, b) => a + b, 0) / lowK.length;
+
+      expect(highMean).toBeLessThan(lowMean);
+    });
+  });
+});

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -1,0 +1,91 @@
+import {
+  baseInterval,
+  calibrationAdjustment,
+  dualProcessAdjustment,
+  computeNextReviewInterval,
+} from '../src/scheduler/calibrationAwareScheduler';
+import { ResponseType, ProcessedResponse, SystemBelief } from '../src/types';
+
+describe('Calibration-Aware Scheduler', () => {
+  describe('baseInterval', () => {
+    it('should return 1 day for low knowledge', () => {
+      expect(baseInterval(0.5, 0.1)).toBe(1);
+    });
+
+    it('should return longer intervals for high knowledge', () => {
+      const interval = baseInterval(0.95, 0.1);
+      expect(interval).toBeGreaterThan(1);
+    });
+
+    it('should return longer intervals for low forgetting rates', () => {
+      const slowForget = baseInterval(0.9, 0.05);
+      const fastForget = baseInterval(0.9, 0.15);
+      expect(slowForget).toBeGreaterThan(fastForget);
+    });
+  });
+
+  describe('calibrationAdjustment', () => {
+    it('should return < 1 for overconfident (shorten interval)', () => {
+      expect(calibrationAdjustment(0.2)).toBeLessThan(1);
+    });
+
+    it('should return > 1 for underconfident (lengthen interval)', () => {
+      expect(calibrationAdjustment(-0.2)).toBeGreaterThan(1);
+    });
+
+    it('should return 1 for well-calibrated', () => {
+      expect(calibrationAdjustment(0)).toBe(1);
+    });
+  });
+
+  describe('dualProcessAdjustment', () => {
+    it('should return 0.5 for errors', () => {
+      expect(dualProcessAdjustment(ResponseType.TYPE2_DELIBERATE, false)).toBe(0.5);
+    });
+
+    it('should return 1.2 for Type 1 correct', () => {
+      expect(dualProcessAdjustment(ResponseType.TYPE1_AUTOMATIC, true)).toBe(1.2);
+    });
+
+    it('should return 1.0 for Type 2 correct', () => {
+      expect(dualProcessAdjustment(ResponseType.TYPE2_DELIBERATE, true)).toBe(1.0);
+    });
+  });
+
+  describe('computeNextReviewInterval', () => {
+    const belief: SystemBelief = {
+      K_hat: 0.8,
+      beta_hat: 0.15,
+      confidence_interval: 0.1,
+      last_updated: new Date(),
+    };
+
+    const response: ProcessedResponse = {
+      item_id: 'test',
+      correctness: true,
+      confidence: 0.7,
+      response_time: 3,
+      timestamp: new Date(),
+      response_type: ResponseType.TYPE2_DELIBERATE,
+      normalized_rt: 0,
+      dual_process_score: 0.5,
+      brier_score: 0.09,
+    };
+
+    it('should return interval within bounds', () => {
+      const interval = computeNextReviewInterval(belief, response, 0.1);
+      expect(interval).toBeGreaterThanOrEqual(1);
+      expect(interval).toBeLessThanOrEqual(60);
+    });
+
+    it('should shorten interval for overconfident learner', () => {
+      const overconfident = { ...belief, beta_hat: 0.3 };
+      const wellCalibrated = { ...belief, beta_hat: 0 };
+
+      const iOver = computeNextReviewInterval(overconfident, response, 0.1);
+      const iWell = computeNextReviewInterval(wellCalibrated, response, 0.1);
+
+      expect(iOver).toBeLessThanOrEqual(iWell);
+    });
+  });
+});

--- a/tests/scoringModule.test.ts
+++ b/tests/scoringModule.test.ts
@@ -1,0 +1,83 @@
+import {
+  brierScore,
+  aggregateBrierScore,
+  expectedCalibrationError,
+  detectMiscalibration,
+} from '../src/calibration/scoringModule';
+import { Response, CalibrationType } from '../src/types';
+
+describe('Calibration Scoring Module', () => {
+  describe('brierScore', () => {
+    it('should return 0 for perfect prediction (correct with 100% confidence)', () => {
+      expect(brierScore(1.0, true)).toBe(0);
+    });
+
+    it('should return 0 for perfect prediction (incorrect with 0% confidence)', () => {
+      expect(brierScore(0.0, false)).toBe(0);
+    });
+
+    it('should return 1 for worst prediction (incorrect with 100% confidence)', () => {
+      expect(brierScore(1.0, false)).toBe(1);
+    });
+
+    it('should return 0.25 for 50% confidence on correct answer', () => {
+      expect(brierScore(0.5, true)).toBe(0.25);
+    });
+  });
+
+  describe('aggregateBrierScore', () => {
+    it('should return average Brier score', () => {
+      const responses: Response[] = [
+        { item_id: '1', correctness: true, confidence: 1.0, response_time: 2, timestamp: new Date() },
+        { item_id: '2', correctness: false, confidence: 0.0, response_time: 2, timestamp: new Date() },
+      ];
+      expect(aggregateBrierScore(responses)).toBe(0);
+    });
+  });
+
+  describe('expectedCalibrationError', () => {
+    it('should return 0 for perfectly calibrated responses', () => {
+      // Create responses where confidence = accuracy in each bin
+      const responses: Response[] = [];
+      const rng = new (require('../src/utils/random').SeededRandom)(42);
+      for (let i = 0; i < 100; i++) {
+        const confidence = (i % 10) / 10 + 0.05;
+        const correctness = rng.random() < confidence;
+        responses.push({
+          item_id: `${i}`,
+          correctness,
+          confidence,
+          response_time: 2,
+          timestamp: new Date(),
+        });
+      }
+      // ECE should be relatively low for many responses
+      const ece = expectedCalibrationError(responses);
+      expect(ece).toBeLessThan(0.2);
+    });
+  });
+
+  describe('detectMiscalibration', () => {
+    it('should detect overconfidence', () => {
+      const responses: Response[] = Array(100).fill(null).map((_, i) => ({
+        item_id: `${i}`,
+        correctness: i < 50, // 50% accuracy
+        confidence: 0.8,    // 80% confidence
+        response_time: 2,
+        timestamp: new Date(),
+      }));
+      expect(detectMiscalibration(responses)).toBe(CalibrationType.OVERCONFIDENT);
+    });
+
+    it('should detect underconfidence', () => {
+      const responses: Response[] = Array(100).fill(null).map((_, i) => ({
+        item_id: `${i}`,
+        correctness: i < 80, // 80% accuracy
+        confidence: 0.5,    // 50% confidence
+        response_time: 2,
+        timestamp: new Date(),
+      }));
+      expect(detectMiscalibration(responses)).toBe(CalibrationType.UNDERCONFIDENT);
+    });
+  });
+});

--- a/tests/simulationEngine.test.ts
+++ b/tests/simulationEngine.test.ts
@@ -1,0 +1,92 @@
+import { runSimulation } from '../src/simulation/simulationEngine';
+import { createLearnerProfile } from '../src/profiles/learnerProfiles';
+import { DEFAULT_SIMULATION_CONFIG, SchedulerType } from '../src/types';
+
+describe('Simulation Engine', () => {
+  // Use fewer items and sessions for faster tests
+  const testConfig = {
+    ...DEFAULT_SIMULATION_CONFIG,
+    num_items: 20,
+    num_sessions: 5,
+    items_per_session: 10,
+    random_seed: 42,
+  };
+
+  describe('runSimulation', () => {
+    it('should run without error for Med-Over profile', () => {
+      const profile = createLearnerProfile('Med-Over', testConfig.num_items);
+      const results = runSimulation(profile, testConfig);
+
+      expect(results).toBeDefined();
+      expect(results.profile_id).toBe('Med-Over');
+      expect(results.session_data).toHaveLength(testConfig.num_sessions);
+    });
+
+    it('should produce increasing K* trajectory for learning', () => {
+      const profile = createLearnerProfile('High-Well', testConfig.num_items);
+      const results = runSimulation(profile, testConfig);
+
+      // K* should generally increase over sessions
+      const first = results.K_star_trajectory[0];
+      const last = results.K_star_trajectory[results.K_star_trajectory.length - 1];
+      expect(last).toBeGreaterThan(first);
+    });
+
+    it('should work with all scheduler types', () => {
+      const schedulers = [
+        SchedulerType.CALIBRATEME,
+        SchedulerType.SM2,
+        SchedulerType.BKT_ONLY,
+        SchedulerType.DECAY_BASED,
+      ];
+
+      for (const scheduler of schedulers) {
+        const profile = createLearnerProfile('Med-Over', testConfig.num_items);
+        const config = { ...testConfig, scheduler_type: scheduler };
+        const results = runSimulation(profile, config);
+
+        expect(results).toBeDefined();
+        expect(results.scheduler_type).toBe(scheduler);
+        expect(results.retention_1day).toBeGreaterThanOrEqual(0);
+        expect(results.retention_1day).toBeLessThanOrEqual(1);
+      }
+    });
+
+    it('should apply scaffolding effects for CalibrateMe', () => {
+      const profile = createLearnerProfile('Med-Over', testConfig.num_items);
+      const config = {
+        ...testConfig,
+        scheduler_type: SchedulerType.CALIBRATEME,
+        enable_scaffolding: true,
+        num_sessions: 15,
+      };
+      const results = runSimulation(profile, config);
+
+      // At least some scaffolds should be delivered
+      const totalScaffolds = results.session_data.reduce(
+        (sum, s) => sum + s.scaffolds_delivered,
+        0
+      );
+      expect(totalScaffolds).toBeGreaterThan(0);
+    });
+
+    it('should produce valid metrics', () => {
+      const profile = createLearnerProfile('Med-Over', testConfig.num_items);
+      const results = runSimulation(profile, testConfig);
+
+      // Retention should be between 0 and 1
+      expect(results.retention_1day).toBeGreaterThanOrEqual(0);
+      expect(results.retention_1day).toBeLessThanOrEqual(1);
+      expect(results.retention_7day).toBeGreaterThanOrEqual(0);
+      expect(results.retention_30day).toBeGreaterThanOrEqual(0);
+
+      // ECE trajectory should have entries
+      expect(results.ece_trajectory).toHaveLength(testConfig.num_sessions);
+
+      // All ECE values should be non-negative
+      results.ece_trajectory.forEach(ece => {
+        expect(ece).toBeGreaterThanOrEqual(0);
+      });
+    });
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "esModuleInterop": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "skipLibCheck": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import path from 'path';
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+});


### PR DESCRIPTION
- Extract and create all source files from markdown codebase documents
- Implement 5 cognitive science modules: BKT belief engine, calibration scoring (ECE/Brier), dual-process classifier, forgetting model, and adaptive scaffolding
- Implement 4 schedulers: CalibrateMe, SM-2, BKT-only, Decay-based
- Define 9 learner profiles (3 Ability x 3 Calibration) from Table 2
- Create simulation engine with progress callbacks and async support
- Build React dashboard with Recharts visualizations
- Add Zustand store with single-run and scheduler comparison modes
- Fix class name bug (CalibrateMe Scheduler -> CalibrateMeScheduler)
- Fix Date serialization issue in calculateUrgency after JSON clone
- Configure Vite, TypeScript, Jest (54 tests passing across 7 suites)

https://claude.ai/code/session_01XqGHemoqZ5jBdtHMrnyLjL